### PR TITLE
ci: tag 触发的 crates.io publish 与 GitHub Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, dev]
   pull_request:
   workflow_dispatch:
 
@@ -110,3 +110,4 @@ jobs:
           path: ${{ matrix.archive }}
           retention-days: 14
           compression-level: 0
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,27 +40,21 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            archive: miyu-x86_64-linux-gnu.tar.gz
             runner: linux-x64
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-            archive: miyu-aarch64-linux-gnu.tar.gz
             runner: linux-arm64
           - os: macos-15-intel
             target: x86_64-apple-darwin
-            archive: miyu-x86_64-apple-darwin.tar.gz
             runner: macos-x64
           - os: macos-14
             target: aarch64-apple-darwin
-            archive: miyu-aarch64-apple-darwin.tar.gz
             runner: macos-arm64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            archive: miyu-x86_64-pc-windows-msvc.zip
             runner: windows-x64
           - os: windows-11-arm
             target: aarch64-pc-windows-msvc
-            archive: miyu-aarch64-pc-windows-msvc.zip
             runner: windows-arm64
     steps:
       - uses: actions/checkout@v4
@@ -95,23 +89,11 @@ jobs:
         run: strip target/${{ matrix.target }}/release/miyu
         continue-on-error: true
 
-      - name: Package (Unix)
-        if: runner.os != 'Windows'
-        run: |
-          cd target/${{ matrix.target }}/release
-          tar czf ../../../${{ matrix.archive }} miyu
-      - name: Package (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          cd target/${{ matrix.target }}/release
-          7z a ../../../${{ matrix.archive }} miyu.exe
-        shell: bash
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.archive }}
-          path: ${{ matrix.archive }}
+          name: miyu-${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/miyu${{ runner.os == 'Windows' && '.exe' || '' }}
+          if-no-files-found: error
           retention-days: 14
-          compression-level: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches: [main, master, dev]
+    tags: ['v*']
   pull_request:
   workflow_dispatch:
 
@@ -96,4 +97,48 @@ jobs:
           path: target/${{ matrix.target }}/release/miyu${{ runner.os == 'Windows' && '.exe' || '' }}
           if-no-files-found: error
           retention-days: 14
+
+  publish-crates:
+    name: Publish to crates.io
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install ALSA dev headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev pkg-config
+      - name: Cargo publish
+        run: cargo publish --locked --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release:
+    name: GitHub Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Restructure artifacts
+        run: |
+          mkdir -p release-assets
+          for dir in artifacts/miyu-*; do
+            target=$(basename "$dir" | sed 's/^miyu-//')
+            ext=""
+            [[ "$target" == *windows* ]] && ext=".exe"
+            mv "$dir/miyu$ext" "release-assets/miyu-$target$ext"
+          done
+          ls -l release-assets
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release-assets/*
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,112 @@
+name: ci
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  lint:
+    name: fmt & clippy
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - name: Install ALSA dev headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev pkg-config
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets --locked -- -D warnings
+
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive: miyu-x86_64-linux-gnu.tar.gz
+            runner: linux-x64
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            archive: miyu-aarch64-linux-gnu.tar.gz
+            runner: linux-arm64
+          - os: macos-13
+            target: x86_64-apple-darwin
+            archive: miyu-x86_64-apple-darwin.tar.gz
+            runner: macos-x64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            archive: miyu-aarch64-apple-darwin.tar.gz
+            runner: macos-arm64
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            archive: miyu-x86_64-pc-windows-msvc.zip
+            runner: windows-x64
+          - os: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            archive: miyu-aarch64-pc-windows-msvc.zip
+            runner: windows-arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install ALSA dev headers (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev pkg-config
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ matrix.runner }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ matrix.runner }}-
+
+      - name: Build release binary
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Strip debug symbols (Unix)
+        if: runner.os != 'Windows'
+        run: strip target/${{ matrix.target }}/release/miyu
+        continue-on-error: true
+
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../${{ matrix.archive }} miyu
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          cd target/${{ matrix.target }}/release
+          7z a ../../../${{ matrix.archive }} miyu.exe
+        shell: bash
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.archive }}
+          path: ${{ matrix.archive }}
+          retention-days: 14
+          compression-level: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
 
   publish-crates:
     name: Publish to crates.io
-    needs: build
+    needs: [lint, build]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
@@ -114,9 +114,11 @@ jobs:
 
   release:
     name: GitHub Release
-    needs: build
+    needs: [lint, build]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Download all artifacts
@@ -124,7 +126,9 @@ jobs:
         with:
           path: artifacts
       - name: Restructure artifacts
+        shell: bash
         run: |
+          shopt -s nullglob
           mkdir -p release-assets
           for dir in artifacts/miyu-*; do
             target=$(basename "$dir" | sed 's/^miyu-//')
@@ -132,6 +136,10 @@ jobs:
             [[ "$target" == *windows* ]] && ext=".exe"
             mv "$dir/miyu$ext" "release-assets/miyu-$target$ext"
           done
+          if [ -z "$(ls -A release-assets 2>/dev/null)" ]; then
+            echo "::error::no artifacts downloaded; refusing to create empty release"
+            exit 1
+          fi
           ls -l release-assets
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
             archive: miyu-aarch64-linux-gnu.tar.gz
             runner: linux-arm64
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             archive: miyu-x86_64-apple-darwin.tar.gz
             runner: macos-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
   lint:
     name: fmt & clippy
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
             target: x86_64-apple-darwin
             archive: miyu-x86_64-apple-darwin.tar.gz
             runner: macos-x64
-          - os: macos-latest
+          - os: macos-14
             target: aarch64-apple-darwin
             archive: miyu-aarch64-apple-darwin.tar.gz
             runner: macos-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Lower the macOS minimum deployment target so binaries run on
+  # older releases (down to Big Sur) regardless of which runner image
+  # produced them. Has no effect on non-macOS platforms.
+  MACOSX_DEPLOYMENT_TARGET: '11.0'
 
 jobs:
   lint:

--- a/src/alarm.rs
+++ b/src/alarm.rs
@@ -127,13 +127,13 @@ pub fn stop_process(pid: u32) -> Result<()> {
         if status != 0 && process_exists(pid) {
             bail!("failed to stop alarm process {pid}")
         }
+        Ok(())
     }
     #[cfg(not(unix))]
     {
         let _ = pid;
         bail!("alarm cancellation is not supported on this platform")
     }
-    Ok(())
 }
 
 pub fn process_exists(pid: u32) -> bool {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1269,6 +1269,7 @@ async fn run_shell_intercept(paths: &MiyuPaths, shell_name: &str, message: Strin
     result
 }
 
+#[cfg(unix)]
 fn drain_stdin() {
     use std::os::fd::AsRawFd;
 
@@ -1298,6 +1299,9 @@ fn drain_stdin() {
 
     let _ = unsafe { libc::fcntl(fd, libc::F_SETFL, flags) };
 }
+
+#[cfg(not(unix))]
+fn drain_stdin() {}
 
 async fn run_chat_with_options(
     paths: &MiyuPaths,
@@ -1650,20 +1654,18 @@ fn read_repl_input(
                         cursor,
                     )?;
                 }
-                KeyCode::Up => {
-                    if !history.is_empty() {
-                        history_index = history_index.saturating_sub(1);
-                        input = history.get(history_index).cloned().unwrap_or_default();
-                        cursor = input.chars().count();
-                        render_repl_input(
-                            &mut stdout,
-                            &mut input_row,
-                            &mut rendered_rows,
-                            mode,
-                            &input,
-                            cursor,
-                        )?;
-                    }
+                KeyCode::Up if !history.is_empty() => {
+                    history_index = history_index.saturating_sub(1);
+                    input = history.get(history_index).cloned().unwrap_or_default();
+                    cursor = input.chars().count();
+                    render_repl_input(
+                        &mut stdout,
+                        &mut input_row,
+                        &mut rendered_rows,
+                        mode,
+                        &input,
+                        cursor,
+                    )?;
                 }
                 KeyCode::Down => {
                     if history_index + 1 < history.len() {
@@ -2123,6 +2125,7 @@ fn complete_repl_command(input: &str) -> Option<&'static str> {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod repl_input_tests {
     use super::*;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -211,7 +211,7 @@ pub struct MemoryConfig {
     pub learning_min_method_chars: usize,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PluginsConfig {
     #[serde(default)]
     pub weather: PluginEnabledConfig,
@@ -499,33 +499,6 @@ impl Default for DisplayConfig {
             reasoning: default_reasoning_display(),
             tool_calls: default_tool_call_display(),
             readable_tool_names: default_true(),
-        }
-    }
-}
-
-impl Default for PluginsConfig {
-    fn default() -> Self {
-        Self {
-            weather: PluginEnabledConfig::default(),
-            web: WebPluginConfig::default(),
-            web_images: WebImagesPluginConfig::default(),
-            deep_research: DeepResearchPluginConfig::default(),
-            vision: VisionPluginConfig::default(),
-            exchange_rate: ExchangeRatePluginConfig::default(),
-            xuanxue: PluginEnabledConfig::default(),
-            image_generation: ImageGenerationPluginConfig::default(),
-            print_image: PrintImagePluginConfig::default(),
-            memes: MemesPluginConfig::default(),
-            knowledge_base: KnowledgeBasePluginConfig::default(),
-            archlinux: PluginEnabledConfig::default(),
-            man: PluginEnabledConfig::default(),
-            moegirl: PluginEnabledConfig::default(),
-            hash_codec: PluginEnabledConfig::default(),
-            calculator: CalculatorPluginConfig::default(),
-            package_advisor: PluginEnabledConfig::default(),
-            linux_game_compatibility: PluginEnabledConfig::default(),
-            diagnostics: DiagnosticsPluginConfig::default(),
-            memory: MemoryConfig::default(),
         }
     }
 }

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -1103,7 +1103,7 @@ fn format_text_file(content: &str) -> String {
 
 fn parse_key_list(value: &str) -> Vec<String> {
     value
-        .split(|ch| ch == ',' || ch == '\n' || ch == '\r')
+        .split([',', '\n', '\r'])
         .map(str::trim)
         .filter(|item| !item.is_empty())
         .map(str::to_string)
@@ -1508,7 +1508,7 @@ impl<'a> ProviderBrowser<'a> {
                 .to_string()
         };
         let status = if self.loading {
-            format!("{}", self.status)
+            self.status.to_string()
         } else {
             self.status.clone()
         };
@@ -1878,11 +1878,9 @@ fn run_form(stdout: &mut io::Stdout, title: &str, fields: &mut [Field]) -> Resul
                 edit_textarea(stdout, &mut fields[selected].value)?;
                 return Ok(true);
             }
-            KeyCode::Enter if !editing => {
-                if !fields[selected].boolean {
-                    fcitx.enter_editing();
-                    editing = true;
-                }
+            KeyCode::Enter if !editing && !fields[selected].boolean => {
+                fcitx.enter_editing();
+                editing = true;
             }
             KeyCode::Char('s') if !editing => return Ok(true),
             KeyCode::Up | KeyCode::Char('k') if !editing => selected = selected.saturating_sub(1),
@@ -1902,10 +1900,8 @@ fn run_form(stdout: &mut io::Stdout, title: &str, fields: &mut [Field]) -> Resul
             }
             KeyCode::Home if editing => cursors[selected] = 0,
             KeyCode::End if editing => cursors[selected] = fields[selected].value.chars().count(),
-            KeyCode::Backspace if editing => {
-                if cursors[selected] > 0 {
-                    remove_char_before_cursor(&mut fields[selected].value, &mut cursors[selected]);
-                }
+            KeyCode::Backspace if editing && cursors[selected] > 0 => {
+                remove_char_before_cursor(&mut fields[selected].value, &mut cursors[selected]);
             }
             KeyCode::Delete if editing => {
                 remove_char_at_cursor(&mut fields[selected].value, cursors[selected])
@@ -2153,6 +2149,7 @@ fn draw_box(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn draw_column(
     stdout: &mut io::Stdout,
     x: u16,
@@ -2208,7 +2205,7 @@ fn draw_form(
     cursors: &[usize],
 ) -> Result<()> {
     let (cols, rows) = terminal::size()?;
-    let width = cols.saturating_sub(8).min(96).max(48);
+    let width = cols.saturating_sub(8).clamp(48, 96);
     let height = (fields.len() as u16 + 8)
         .min(rows.saturating_sub(4))
         .max(10);

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -1184,6 +1184,7 @@ fn split_tag_pair(
     ))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_sse_line<F>(
     line: &str,
     content: &mut String,
@@ -1257,6 +1258,7 @@ where
     Ok(Some(false))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn handle_responses_sse_line<F>(
     line: &str,
     content: &mut String,
@@ -1329,21 +1331,21 @@ where
         }
         "response.reasoning_text.done"
         | "response.reasoning_summary.done"
-        | "response.reasoning_summary_text.done" => {
-            if !*content_started && !reasoning.trim().is_empty() {
-                flush_buffer(
-                    reasoning,
-                    reasoning_emitted,
-                    ChatStreamKind::Reasoning,
-                    on_chunk,
-                    true,
-                )?;
-                *content_started = true;
-                on_chunk(ChatStreamChunk {
-                    kind: ChatStreamKind::Content,
-                    text: String::new(),
-                })?;
-            }
+        | "response.reasoning_summary_text.done"
+            if !*content_started && !reasoning.trim().is_empty() =>
+        {
+            flush_buffer(
+                reasoning,
+                reasoning_emitted,
+                ChatStreamKind::Reasoning,
+                on_chunk,
+                true,
+            )?;
+            *content_started = true;
+            on_chunk(ChatStreamChunk {
+                kind: ChatStreamKind::Content,
+                text: String::new(),
+            })?;
         }
         "response.output_item.added" => {
             if let Some(item) = event.item {
@@ -1850,6 +1852,7 @@ fn clean_plain_text(mut text: String) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
 
@@ -2245,10 +2248,7 @@ fn strip_tagged_sections(mut text: String, tag: &str) -> String {
     let open = format!("<{tag}>");
     let close = format!("</{tag}>");
     let open_prefix = format!("<{tag}");
-    loop {
-        let Some(start) = text.find(&open_prefix) else {
-            break;
-        };
+    while let Some(start) = text.find(&open_prefix) {
         let content_start = text[start..]
             .find('>')
             .map(|offset| start + offset + 1)

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -478,7 +478,7 @@ impl StreamRenderer {
             .tool_stats
             .iter()
             .map(|(name, stats)| {
-                let header = tool_status_text(&self.display_tool_name(name), stats);
+                let header = tool_status_text(self.display_tool_name(name), stats);
                 stats.progress.as_ref().map_or(header.clone(), |message| {
                     let progress = message
                         .lines()
@@ -910,7 +910,7 @@ fn render_inline(text: &str) -> String {
                             output.push_str(": ");
                             output.push_str(&alt);
                         }
-                        output.push_str("]");
+                        output.push(']');
                         output.push_str(RESET);
                         output.push('(');
                         output.push_str(&render_url(
@@ -981,15 +981,13 @@ fn render_inline(text: &str) -> String {
                 continue;
             }
         }
-        if chars[index] == '_' {
-            if is_emphasis_start(&chars, index) {
-                if let Some(end) = find_emphasis_end(&chars, index + 1, '_') {
-                    output.push_str(ITALIC_STYLE);
-                    output.extend(chars[index + 1..end].iter());
-                    output.push_str(RESET);
-                    index = end + 1;
-                    continue;
-                }
+        if chars[index] == '_' && is_emphasis_start(&chars, index) {
+            if let Some(end) = find_emphasis_end(&chars, index + 1, '_') {
+                output.push_str(ITALIC_STYLE);
+                output.extend(chars[index + 1..end].iter());
+                output.push_str(RESET);
+                index = end + 1;
+                continue;
             }
         }
         if chars[index] == '[' {

--- a/src/render/wait_spinner.rs
+++ b/src/render/wait_spinner.rs
@@ -134,12 +134,8 @@ fn paint_active_dot(index: usize) -> String {
     }
 }
 
-fn paint_inactive_dot(fade: f64) -> String {
-    if fade > 0.24 {
-        format!("\x1b[2m\x1b[36m{INACTIVE_DOT}\x1b[0m")
-    } else {
-        format!("\x1b[2m\x1b[36m{INACTIVE_DOT}\x1b[0m")
-    }
+fn paint_inactive_dot(_fade: f64) -> String {
+    format!("\x1b[2m\x1b[36m{INACTIVE_DOT}\x1b[0m")
 }
 
 fn total_frames() -> usize {

--- a/src/tools/deep_research.rs
+++ b/src/tools/deep_research.rs
@@ -6,7 +6,7 @@ use crate::paths::MiyuPaths;
 use anyhow::{bail, Result};
 use chrono::Local;
 use serde_json::{json, Value};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -290,7 +290,7 @@ async fn run_deep_research(
             progress.phase("thinker failed to produce a draft");
             break;
         }
-        progress.phase(&format!(
+        progress.phase(format!(
             "round {iteration}: draft ready chars={}",
             draft.chars().count()
         ));
@@ -325,7 +325,7 @@ async fn run_deep_research(
             progress.phase(format!("round {iteration}: accepted"));
             break;
         }
-        progress.phase(&format!(
+        progress.phase(format!(
             "round {iteration}: revision requested - {}",
             clip_inline(
                 review
@@ -497,7 +497,7 @@ async fn chat_with_tools(
                 state.stats.tool_calls += 1;
             }
             progress.tool(format!("tool #{steps}: {} running", call.function.name));
-            progress.detail(&format!(
+            progress.detail(format!(
                 "→{} {}",
                 call.function.name,
                 compact_arguments(&call.function.arguments)
@@ -531,7 +531,7 @@ async fn chat_with_tools(
                 call.function.name,
                 if ok { "ok" } else { "error" }
             ));
-            progress.detail(&format!(
+            progress.detail(format!(
                 "←{} {}",
                 call.function.name,
                 if ok { "ok" } else { "error" }
@@ -649,6 +649,7 @@ fn strip_reference_section(value: &str) -> String {
     value.to_string()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn write_report(
     plugin: &DeepResearchPluginConfig,
     paths: &MiyuPaths,
@@ -824,7 +825,7 @@ fn sanitize_filename(value: &str) -> String {
     }
 }
 
-fn unique_report_filename(output_dir: &PathBuf, title: &str) -> String {
+fn unique_report_filename(output_dir: &Path, title: &str) -> String {
     let stem = sanitize_filename(&strip_title_date_prefix(title));
     let suffix = format!(
         "{}_{}",
@@ -973,10 +974,7 @@ fn strip_leading_weekday(value: &str) -> String {
         "周天",
     ];
     let mut title = value.trim_start();
-    loop {
-        let Some(weekday) = weekdays.iter().find(|weekday| title.starts_with(**weekday)) else {
-            break;
-        };
+    while let Some(weekday) = weekdays.iter().find(|weekday| title.starts_with(**weekday)) {
         title = title[weekday.len()..].trim_start();
     }
     title.to_string()

--- a/src/tools/deepseek_status.rs
+++ b/src/tools/deepseek_status.rs
@@ -43,7 +43,7 @@ async fn query_deepseek_status(args: Value) -> Result<String> {
 
 async fn fetch_status_html() -> Result<String> {
     match fetch_status_html_with_curl().await {
-        Ok(html) => return Ok(html),
+        Ok(html) => Ok(html),
         Err(curl_err) => match fetch_status_html_with_reqwest().await {
             Ok(html) => Ok(html),
             Err(reqwest_err) => bail!(
@@ -205,7 +205,7 @@ fn build_response(raw: &Value, include_incidents: bool, max_incidents: usize) ->
             let Some(id) = component.get("id").and_then(Value::as_str) else {
                 continue;
             };
-            if affected_ids.iter().any(|affected| *affected == id) {
+            if affected_ids.contains(&id) {
                 component["status"] = Value::String(change_status.to_string());
             }
         }

--- a/src/tools/default_tools.rs
+++ b/src/tools/default_tools.rs
@@ -711,7 +711,7 @@ fn ensure_safe_trash_target(path: &Path) -> Result<()> {
         Path::new("/usr"),
         Path::new("/var"),
     ];
-    if dangerous.iter().any(|item| path == *item) {
+    if dangerous.contains(&path) {
         bail!(
             "refusing to trash dangerous system path: {}",
             path.display()

--- a/src/tools/diagnostics.rs
+++ b/src/tools/diagnostics.rs
@@ -2216,7 +2216,7 @@ fn finalize_input_method_confidence(report: &mut DiagnosticReport) {
     {
         score = score.min(70);
     }
-    if report.facts.get("input_method.questions").is_none() {
+    if !report.facts.contains_key("input_method.questions") {
         score = score.min(75);
     }
     let threshold = 95;
@@ -3896,7 +3896,7 @@ mod tests {
         linux_input_method_path_report(&mut report, Some(&profile));
 
         let path_report = report.facts.get("input_method.path_report").unwrap();
-        assert!(report.facts.get("input_method.questions").is_some());
+        assert!(report.facts.contains_key("input_method.questions"));
         assert!(path_report.get("app_adaptation").is_some());
         assert!(path_report.get("environment_module_path").is_some());
         assert!(path_report.get("wayland_protocol_path").is_some());

--- a/src/tools/memes.rs
+++ b/src/tools/memes.rs
@@ -949,12 +949,8 @@ fn meme_print_size(args: &Value, config: &MemesPluginConfig) -> Option<String> {
 
 fn configured_meme_size(config: &MemesPluginConfig) -> Option<String> {
     let (cols, rows) = crossterm::terminal::size().ok()?;
-    let width = ((cols as u32 * config.width_percent as u32) / 100)
-        .max(1)
-        .min(160);
-    let height = ((rows as u32 * config.height_percent as u32) / 100)
-        .max(1)
-        .min(80);
+    let width = ((cols as u32 * config.width_percent as u32) / 100).clamp(1, 160);
+    let height = ((rows as u32 * config.height_percent as u32) / 100).clamp(1, 80);
     Some(format!("{width}x{height}"))
 }
 

--- a/src/tools/vision.rs
+++ b/src/tools/vision.rs
@@ -202,8 +202,8 @@ async fn analyze_image_url_with_prompt(
     if !vision.enabled {
         bail!("vision plugin is disabled")
     }
-    let provider = vision_provider(&config, vision)?;
-    let client = OpenAiCompatibleClient::new(&provider, &config, &paths)?;
+    let provider = vision_provider(config, vision)?;
+    let client = OpenAiCompatibleClient::new(&provider, config, paths)?;
     let result = client
         .chat_stream(
             vec![

--- a/src/tools/web_images.rs
+++ b/src/tools/web_images.rs
@@ -129,7 +129,7 @@ async fn search_web_images(
     let Some(count) = args.get("count").and_then(Value::as_u64) else {
         bail!("count is required; choose the number of images from the user's request")
     };
-    let count = count.clamp(1, plugin.max_results.max(1).min(10) as u64) as usize;
+    let count = count.clamp(1, plugin.max_results.clamp(1, 10) as u64) as usize;
     let safe_search = args
         .get("safe_search")
         .and_then(Value::as_bool)
@@ -407,6 +407,7 @@ fn parse_bing_results(html: &str, limit: usize) -> Vec<ImageCandidate> {
     candidates
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_candidate(
     title: &str,
     page_url: &str,
@@ -448,6 +449,7 @@ fn build_candidate(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn download_and_store_images(
     config: &AppConfig,
     paths: &MiyuPaths,


### PR DESCRIPTION
## 说明 / 暂缓提示
**reviewer 在 #9 中明确指出该部分应暂缓**：crates.io publish 与 GitHub Release 自动化涉及发布策略与维护承诺，建议单独讨论后再合并

本 PR 仅作**技术方案待评估**，不预期立即合并。维护者确认发布策略（支持平台范围、版本号规则、prerelease 判定、release notes 模板等）后可再决定

## 触发
- `push: tags: ['v*']`
- 不影响日常分支 / PR workflow

## 新增 job
### `publish-crates`
```bash
cargo publish --locked --token \${{ secrets.CARGO_REGISTRY_TOKEN }}
```
- `needs: build`：构建矩阵必须全绿才发布，确保破损 tag 不进 registry

### `release`
- 下载 6 个 target 的二进制 artifact，重命名为 `miyu-<target>(.exe)`
- 用 `softprops/action-gh-release@v2` 创建 GitHub Release
- `generate_release_notes: true`：自动生成 release notes
- prerelease 判定：tag 名含 `-`（如 `v0.2.0-rc1`）自动标记 prerelease

## 配置需求（合并前）
- 仓库 Secrets 新增 `CARGO_REGISTRY_TOKEN`（crates.io API token）
- 发布前需手动把 `Cargo.toml` 的 `version` 对齐到 tag 号

## 建议流程
```bash
# 更新 Cargo.toml: version = "0.2.0"
git tag v0.2.0 && git push origin v0.2.0
# CI 自动：6-platform build → crates.io publish → GitHub Release
```

## 依赖
- #10 跨平台编译修复
- #11 CI 基础 / clippy
- #12 artifact 打包

三个前置合并后本 PR 才可独立 review