### PR TITLE
feat(config): 支持为 Provider 配置额外请求体参数 (extra_body)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -161,6 +161,9 @@ pub struct ProviderConfig {
         skip_serializing_if = "is_default_anthropic_max_tokens"
     )]
     pub anthropic_max_tokens: u32,
+    #[serde(flatten)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_body: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone)]
@@ -933,6 +936,7 @@ impl ProviderConfig {
             timeout_seconds: default_timeout(),
             temperature: default_temperature(),
             anthropic_max_tokens: default_anthropic_max_tokens(),
+            extra_body: None
         }
     }
 
@@ -950,6 +954,7 @@ impl ProviderConfig {
             timeout_seconds: default_timeout(),
             temperature: default_temperature(),
             anthropic_max_tokens: default_anthropic_max_tokens(),
+            extra_body:None
         }
     }
 
@@ -991,6 +996,7 @@ impl ProviderConfig {
             timeout_seconds: default_timeout(),
             temperature: default_temperature(),
             anthropic_max_tokens: default_anthropic_max_tokens(),
+            extra_body:None
         }
     }
 
@@ -1008,6 +1014,7 @@ impl ProviderConfig {
             timeout_seconds: default_timeout(),
             temperature: default_temperature(),
             anthropic_max_tokens: default_anthropic_max_tokens(),
+            extra_body:None
         }
     }
 

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -1792,6 +1792,7 @@ fn edit_provider_form(
         ),
         Field::new("超时秒数", provider.timeout_seconds.to_string()),
         Field::new("Temperature", provider.temperature.to_string()),
+        Field::textarea("额外请求体(JSON)",provider.extra_body.as_ref().map(|v| v.to_string()).unwrap_or_default()),
     ];
     if !run_form(stdout, " EDIT PROVIDER ", &mut fields)? {
         return Ok(None);
@@ -1810,6 +1811,21 @@ fn edit_provider_form(
     if !default_model.trim().is_empty() && !models.iter().any(|item| item == &default_model) {
         models.push(default_model.clone());
     }
+    //解析extra_body JSON
+    let extra_body = if fields[9].value.trim().is_empty() {
+        None
+    } else {
+        match serde_json::from_str(&fields[9].value.trim()) {
+            Ok(json) => Some(json),
+            Err(e) => {
+                // 显示错误并返回，让用户重新编辑
+                let error_msg = format!("无效 JSON: {}", e);
+                message(stdout, &error_msg)?;
+                return Ok(None);
+            }
+        }
+    };
+
     Ok(Some(ProviderConfig {
         id: fields[0].value.trim().to_string(),
         display_name: fields[1].value.trim().to_string(),
@@ -1823,6 +1839,7 @@ fn edit_provider_form(
         timeout_seconds: fields[7].value.trim().parse().unwrap_or(60),
         temperature: fields[8].value.trim().parse().unwrap_or(0.7),
         anthropic_max_tokens: provider.anthropic_max_tokens,
+        extra_body,
     }))
 }
 

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -411,6 +411,7 @@ impl OpenAiCompatibleClient {
             }),
             tools: (!tools.is_empty()).then_some(tools),
             chat_template_kwargs: taotoken_glm_chat_template_kwargs(&self.provider),
+            extra_body: self.provider.extra_body.clone(),
         };
         let url = format!(
             "{}/chat/completions",
@@ -659,6 +660,7 @@ impl OpenAiCompatibleClient {
             max_tokens: self.provider.anthropic_max_tokens,
             temperature: Some(self.provider.temperature),
             thinking: thinking.then(anthropic_thinking_config),
+            extra_body: self.provider.extra_body.clone()
         }
     }
 
@@ -735,6 +737,7 @@ impl OpenAiCompatibleClient {
                 summary: Some("concise"),
             }),
             temperature: Some(self.provider.temperature),
+            extra_body: self.provider.extra_body.clone(),
         };
         let url = format!("{}/responses", self.provider.base_url.trim_end_matches('/'));
         let response = self
@@ -926,6 +929,9 @@ struct ChatRequest {
     tools: Option<Vec<ToolDefinition>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     chat_template_kwargs: Option<ChatTemplateKwargs>,
+    #[serde(flatten)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra_body: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -946,6 +952,9 @@ struct ResponsesRequest {
     reasoning: Option<ResponsesReasoning>,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f32>,
+    #[serde(flatten)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra_body: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -970,6 +979,9 @@ struct AnthropicRequest {
     temperature: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     thinking: Option<AnthropicThinkingConfig>,
+    #[serde(flatten)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra_body: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -2731,6 +2743,7 @@ mod tests {
             }),
             tools: None,
             chat_template_kwargs: None,
+            extra_body: None
         };
 
         let value = serde_json::to_value(request).unwrap();


### PR DESCRIPTION
## 概述
为 Provider 配置增加 `extra_body` 字段，允许用户自定义任意 JSON 格式的额外参数，并在 LLM 请求体中展平。这解决了 DeepSeek V4 等模型默认启用思考模式、但用户希望关闭的问题，也适用于其他需传递扩展参数的场景（如 `reasoning_effort`、`enable_thinking` 等）。

## 实现内容
- **配置结构 (`config.rs`)**  
  - `ProviderConfig` 新增 `extra_body: Option<serde_json::Value>`，默认 `None`。  
  - 所有构造方法均已补全该字段。

- **LLM 请求构造**  
  - 在 `ChatRequest`、`ResponsesRequest`、`AnthropicRequest` 中增加 `#[serde(flatten)] extra_body`，使其序列化时与顶层字段合并。  
  - 在 `OpenAiCompatibleClient` 的请求构建处，从 `provider.extra_body` 克隆并赋值。

- **TUI 配置界面 (`config_tui.rs`)**  
  - `edit_provider_form` 表单中新增“额外请求体 (JSON)”多行文本域，支持外部编辑器编辑。  
  - 保存时自动校验 JSON 合法性，若格式错误则提示用户重新编辑。

## 向后兼容性
- 现有配置文件不受影响，`extra_body` 缺失时默认 `None`，请求体不发生变化。  
- 代码中所有构造 `ProviderConfig` 的地方均赋予 `None`，保持行为一致。

## 使用示例
在配置文件中为 DeepSeek 显式禁用思考：
```jsonc
{
  "providers": [
    {
      "id": "deepseek",
      "base_url": "https://api.deepseek.com",
      "default_model": "deepseek-v4-flash",
      "extra_body": {
        "thinking": {"type": "enabled"}
      }
    }
  ]
} 
经过我的测试，deepseek-v4添加字段后能控制是否启用思考以及思考强度 