### PR TITLE
feat(config): 支持为 Provider 配置额外请求体参数 (extra_body)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -161,6 +161,9 @@ pub struct ProviderConfig {
         skip_serializing_if = "is_default_anthropic_max_tokens"
     )]
     pub anthropic_max_tokens: u32,
+    #[serde(flatten)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_body: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone)]
@@ -933,6 +936,7 @@ impl ProviderConfig {
             timeout_seconds: default_timeout(),
             temperature: default_temperature(),
             anthropic_max_tokens: default_anthropic_max_tokens(),
+            extra_body: None
         }
     }
 
@@ -950,6 +954,7 @@ impl ProviderConfig {
             timeout_seconds: default_timeout(),
             temperature: default_temperature(),
             anthropic_max_tokens: default_anthropic_max_tokens(),
+            extra_body:None
         }
     }
 
@@ -991,6 +996,7 @@ impl ProviderConfig {
             timeout_seconds: default_timeout(),
             temperature: default_temperature(),
             anthropic_max_tokens: default_anthropic_max_tokens(),
+            extra_body:None
         }
     }
 
@@ -1008,6 +1014,7 @@ impl ProviderConfig {
             timeout_seconds: default_timeout(),
             temperature: default_temperature(),
             anthropic_max_tokens: default_anthropic_max_tokens(),
+            extra_body:None
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -161,7 +161,6 @@ pub struct ProviderConfig {
         skip_serializing_if = "is_default_anthropic_max_tokens"
     )]
     pub anthropic_max_tokens: u32,
-    #[serde(flatten)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extra_body: Option<serde_json::Value>,
 }
@@ -936,7 +935,7 @@ impl ProviderConfig {
             timeout_seconds: default_timeout(),
             temperature: default_temperature(),
             anthropic_max_tokens: default_anthropic_max_tokens(),
-            extra_body: None
+            extra_body: None,
         }
     }
 
@@ -954,7 +953,7 @@ impl ProviderConfig {
             timeout_seconds: default_timeout(),
             temperature: default_temperature(),
             anthropic_max_tokens: default_anthropic_max_tokens(),
-            extra_body:None
+            extra_body: None,
         }
     }
 
@@ -996,7 +995,7 @@ impl ProviderConfig {
             timeout_seconds: default_timeout(),
             temperature: default_temperature(),
             anthropic_max_tokens: default_anthropic_max_tokens(),
-            extra_body:None
+            extra_body: None,
         }
     }
 
@@ -1014,7 +1013,7 @@ impl ProviderConfig {
             timeout_seconds: default_timeout(),
             temperature: default_temperature(),
             anthropic_max_tokens: default_anthropic_max_tokens(),
-            extra_body:None
+            extra_body: None,
         }
     }
 
@@ -2565,5 +2564,37 @@ mod tests {
         assert!(!memes.auto_send_enabled);
         assert_eq!(memes.search_max_results, 1);
         assert_eq!(memes.auto_send_probability, 0.2);
+    }
+
+    #[test]
+    fn extra_body_roundtrip() {
+        // 构造一个包含 extra_body 的 ProviderConfig
+        let original = ProviderConfig {
+            id: "test".to_string(),
+            display_name: "Test".to_string(),
+            base_url: "https://example.com".to_string(),
+            protocol: "auto".to_string(),
+            api_key: None,
+            models: vec![],
+            model_context_window: HashMap::new(),
+            model_modalities: HashMap::new(),
+            default_model: String::new(),
+            timeout_seconds: 60,
+            temperature: 0.7,
+            anthropic_max_tokens: 4096,
+            extra_body: Some(
+                serde_json::json!({ "enable_thinking": false, "reasoning_effort": "low" }),
+            ),
+        };
+
+        // 序列化为 JSON 字符串
+        let serialized = serde_json::to_string(&original).unwrap();
+        // 反序列化回来
+        let deserialized: ProviderConfig = serde_json::from_str(&serialized).unwrap();
+
+        // 比较两个对象的 extra_body 字段是否相等
+        assert_eq!(original.extra_body, deserialized.extra_body);
+        // 也可比较其他字段确保一致
+        assert_eq!(original.id, deserialized.id);
     }
 }

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -1770,6 +1770,14 @@ fn edit_provider_form(
         .get(&provider.default_model)
         .copied()
         .unwrap_or_default();
+
+    // 将 extra_body 格式化为 JSON 字符串，方便编辑
+    let extra_body_string = provider
+        .extra_body
+        .as_ref()
+        .and_then(|v| serde_json::to_string_pretty(v).ok())
+        .unwrap_or_default();
+
     let mut fields = vec![
         Field::new("配置 ID", provider.id.clone()),
         Field::new("显示名称", provider.display_name.clone()),
@@ -1792,57 +1800,79 @@ fn edit_provider_form(
         ),
         Field::new("超时秒数", provider.timeout_seconds.to_string()),
         Field::new("Temperature", provider.temperature.to_string()),
-        Field::textarea("额外请求体(JSON)",provider.extra_body.as_ref().map(|v| v.to_string()).unwrap_or_default()),
+        Field::textarea("额外请求体 (JSON)", extra_body_string),
     ];
-    if !run_form(stdout, " EDIT PROVIDER ", &mut fields)? {
-        return Ok(None);
-    }
-    let default_model = fields[5].value.trim().to_string();
-    let mut model_context_window = provider.model_context_window.clone();
-    match fields[6].value.trim().parse::<usize>().unwrap_or_default() {
-        0 => {
-            model_context_window.remove(&default_model);
+
+    // 循环直到用户取消或输入合法 JSON 对象
+    loop {
+        if !run_form(stdout, " EDIT PROVIDER ", &mut fields)? {
+            return Ok(None);
         }
-        value => {
-            model_context_window.insert(default_model.clone(), value);
-        }
-    }
-    let mut models = provider.models.clone();
-    if !default_model.trim().is_empty() && !models.iter().any(|item| item == &default_model) {
-        models.push(default_model.clone());
-    }
-    //解析extra_body JSON
-    let extra_body = if fields[9].value.trim().is_empty() {
-        None
-    } else {
-        match serde_json::from_str(&fields[9].value.trim()) {
-            Ok(json) => Some(json),
-            Err(e) => {
-                // 显示错误并返回，让用户重新编辑
-                let error_msg = format!("无效 JSON: {}", e);
-                message(stdout, &error_msg)?;
-                return Ok(None);
+
+        // 提取各个字段的值（索引保持不变）
+        let default_model = fields[5].value.trim().to_string();
+        let model_context_window_raw = fields[6].value.trim().parse::<usize>().unwrap_or_default();
+        let timeout = fields[7].value.trim().parse().unwrap_or(60);
+        let temperature = fields[8].value.trim().parse().unwrap_or(0.7);
+
+        // 解析 extra_body
+        let extra_body = if fields[9].value.trim().is_empty() {
+            None
+        } else {
+            // 在 match 中显式标注类型
+            match serde_json::from_str::<serde_json::Value>(&fields[9].value.trim()) {
+                Ok(json) => {
+                    if json.is_object() {
+                        Some(json)
+                    } else {
+                        message(
+                            stdout,
+                            "额外请求体必须是 JSON 对象 (如 {\"key\": \"value\"})",
+                        )?;
+                        continue;
+                    }
+                }
+                Err(e) => {
+                    message(stdout, &format!("无效 JSON: {}", e))?;
+                    continue;
+                }
+            }
+        };
+
+        // 构建 model_context_window
+        let mut model_context_window = provider.model_context_window.clone();
+        match model_context_window_raw {
+            0 => {
+                model_context_window.remove(&default_model);
+            }
+            value => {
+                model_context_window.insert(default_model.clone(), value);
             }
         }
-    };
 
-    Ok(Some(ProviderConfig {
-        id: fields[0].value.trim().to_string(),
-        display_name: fields[1].value.trim().to_string(),
-        base_url: normalize_base_url(&fields[2].value),
-        protocol: fields[3].value.trim().to_string(),
-        api_key: Some(fields[4].value.trim().to_string()).filter(|value| !value.is_empty()),
-        models,
-        model_context_window,
-        model_modalities: provider.model_modalities.clone(),
-        default_model,
-        timeout_seconds: fields[7].value.trim().parse().unwrap_or(60),
-        temperature: fields[8].value.trim().parse().unwrap_or(0.7),
-        anthropic_max_tokens: provider.anthropic_max_tokens,
-        extra_body,
-    }))
+        let mut models = provider.models.clone();
+        if !default_model.trim().is_empty() && !models.iter().any(|item| item == &default_model) {
+            models.push(default_model.clone());
+        }
+
+        // 所有验证通过，返回新的 ProviderConfig
+        return Ok(Some(ProviderConfig {
+            id: fields[0].value.trim().to_string(),
+            display_name: fields[1].value.trim().to_string(),
+            base_url: normalize_base_url(&fields[2].value),
+            protocol: fields[3].value.trim().to_string(),
+            api_key: Some(fields[4].value.trim().to_string()).filter(|value| !value.is_empty()),
+            models,
+            model_context_window,
+            model_modalities: provider.model_modalities.clone(),
+            default_model,
+            timeout_seconds: timeout,
+            temperature: temperature,
+            anthropic_max_tokens: provider.anthropic_max_tokens,
+            extra_body,
+        }));
+    }
 }
-
 fn edit_model_form(
     stdout: &mut io::Stdout,
     provider: &mut ProviderConfig,
@@ -2998,5 +3028,22 @@ mod tests {
         let field = Field::textarea("API Keys", String::new()).sensitive();
 
         assert_eq!(field_display_value(&field, false), "(Enter 打开 $EDITOR)");
+    }
+
+    #[test]
+    fn extra_body_reject_non_object() {
+        let invalid_inputs = vec!["true", "\"hello\"", "[1, 2, 3]"];
+
+        for input in invalid_inputs {
+            let result = serde_json::from_str::<serde_json::Value>(input);
+            assert!(result.is_ok());
+            let json = result.unwrap();
+            assert!(!json.is_object(), "Non-object JSON should be rejected");
+            // 在你的 TUI 逻辑中，你会检查 is_object() 并报错，这里模拟
+            if !json.is_object() {
+                // 模拟错误处理
+                assert!(true); // 测试通过
+            }
+        }
     }
 }

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -1792,6 +1792,7 @@ fn edit_provider_form(
         ),
         Field::new("超时秒数", provider.timeout_seconds.to_string()),
         Field::new("Temperature", provider.temperature.to_string()),
+        Field::textarea("额外请求体(JSON)",provider.extra_body.as_ref().map(|v| v.to_string()).unwrap_or_default()),
     ];
     if !run_form(stdout, " EDIT PROVIDER ", &mut fields)? {
         return Ok(None);
@@ -1810,6 +1811,21 @@ fn edit_provider_form(
     if !default_model.trim().is_empty() && !models.iter().any(|item| item == &default_model) {
         models.push(default_model.clone());
     }
+    //解析extra_body JSON
+    let extra_body = if fields[9].value.trim().is_empty() {
+        None
+    } else {
+        match serde_json::from_str(&fields[9].value.trim()) {
+            Ok(json) => Some(json),
+            Err(e) => {
+                // 显示错误并返回，让用户重新编辑
+                let error_msg = format!("无效 JSON: {}", e);
+                message(stdout, &error_msg)?;
+                return Ok(None);
+            }
+        }
+    };
+
     Ok(Some(ProviderConfig {
         id: fields[0].value.trim().to_string(),
         display_name: fields[1].value.trim().to_string(),
@@ -1823,6 +1839,7 @@ fn edit_provider_form(
         timeout_seconds: fields[7].value.trim().parse().unwrap_or(60),
         temperature: fields[8].value.trim().parse().unwrap_or(0.7),
         anthropic_max_tokens: provider.anthropic_max_tokens,
+        extra_body,
     }))
 }
 

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -20,6 +20,26 @@ static TOOL_CALL_COUNTER: AtomicU64 = AtomicU64::new(0);
 static LLM_SCHEDULER: LazyLock<Mutex<LlmScheduler>> =
     LazyLock::new(|| Mutex::new(LlmScheduler::default()));
 
+//过滤 extra_body 中与保留字段冲突的键
+fn sanitize_extra_body(
+    extra: Option<serde_json::Value>,
+    reserved_keys: &[&str],
+) -> Option<serde_json::Value> {
+    let mut extra = extra?;
+    if let Some(obj) = extra.as_object_mut() {
+        for key in reserved_keys {
+            obj.remove(*key);
+        }
+        //若过滤后为空对象，返回None
+        if obj.is_empty() {
+            return None;
+        }
+        return Some(serde_json::Value::Object(obj.clone()));
+    } else {
+        return Some(extra);
+    }
+}
+
 fn gen_tool_call_id() -> String {
     let ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -401,6 +421,18 @@ impl OpenAiCompatibleClient {
                 bail!("OpenAI Responses protocol is not supported by this provider");
             }
         }
+        let extra_body = sanitize_extra_body(
+            self.provider.extra_body.clone(),
+            &[
+                "model",
+                "messages",
+                "temperature",
+                "stream",
+                "stream_options",
+                "tools",
+                "chat_template_kwargs",
+            ],
+        );
         let mut request = ChatRequest {
             model: self.provider.default_model.clone(),
             messages,
@@ -411,7 +443,7 @@ impl OpenAiCompatibleClient {
             }),
             tools: (!tools.is_empty()).then_some(tools),
             chat_template_kwargs: taotoken_glm_chat_template_kwargs(&self.provider),
-            extra_body: self.provider.extra_body.clone(),
+            extra_body: extra_body,
         };
         let url = format!(
             "{}/chat/completions",
@@ -644,13 +676,24 @@ impl OpenAiCompatibleClient {
 
         self.consume_anthropic_stream(response, on_chunk).await
     }
-
     fn anthropic_request(
         &self,
         messages: Vec<ChatMessage>,
         tools: Vec<ToolDefinition>,
         thinking: bool,
     ) -> AnthropicRequest {
+        let extra_body = sanitize_extra_body(
+            self.provider.extra_body.clone(),
+            &[
+                "model",
+                "messages",
+                "temperature",
+                "stream",
+                "stream_options",
+                "tools",
+                "chat_template_kwargs",
+            ],
+        );
         AnthropicRequest {
             model: self.provider.default_model.clone(),
             system: lower_anthropic_system(&messages),
@@ -660,7 +703,7 @@ impl OpenAiCompatibleClient {
             max_tokens: self.provider.anthropic_max_tokens,
             temperature: Some(self.provider.temperature),
             thinking: thinking.then(anthropic_thinking_config),
-            extra_body: self.provider.extra_body.clone()
+            extra_body: extra_body,
         }
     }
 
@@ -726,6 +769,18 @@ impl OpenAiCompatibleClient {
     where
         F: FnMut(ChatStreamChunk) -> Result<()>,
     {
+        let extra_body = sanitize_extra_body(
+            self.provider.extra_body.clone(),
+            &[
+                "model",
+                "messages",
+                "temperature",
+                "stream",
+                "stream_options",
+                "tools",
+                "chat_template_kwargs",
+            ],
+        );
         let request = ResponsesRequest {
             model: self.provider.default_model.clone(),
             input: lower_responses_messages(messages),
@@ -737,7 +792,7 @@ impl OpenAiCompatibleClient {
                 summary: Some("concise"),
             }),
             temperature: Some(self.provider.temperature),
-            extra_body: self.provider.extra_body.clone(),
+            extra_body: extra_body,
         };
         let url = format!("{}/responses", self.provider.base_url.trim_end_matches('/'));
         let response = self
@@ -2743,7 +2798,7 @@ mod tests {
             }),
             tools: None,
             chat_template_kwargs: None,
-            extra_body: None
+            extra_body: None,
         };
 
         let value = serde_json::to_value(request).unwrap();
@@ -3305,7 +3360,142 @@ mod tests {
             timeout_seconds: 60,
             temperature: 0.7,
             anthropic_max_tokens: 4096,
+            extra_body: None,
         }
+    }
+
+    #[test]
+    fn test_chat_request_extra_body_flatten() {
+        use serde_json::json;
+
+        let extra = Some(json!({
+            "enable_thinking": false,
+            "custom_param": "value"
+        }));
+
+        let request = ChatRequest {
+            model: "gpt-4".to_string(),
+            messages: vec![ChatMessage::plain("user", "Hello")],
+            temperature: 0.7,
+            stream: true,
+            stream_options: Some(ChatStreamOptions {
+                include_usage: true,
+            }),
+            tools: None,
+            chat_template_kwargs: None,
+            extra_body: extra.clone(),
+        };
+
+        let value = serde_json::to_value(&request).unwrap();
+
+        // 验证展平字段
+        assert_eq!(value["enable_thinking"], false);
+        assert_eq!(value["custom_param"], "value");
+
+        // 验证顶层字段
+        assert_eq!(value["model"], "gpt-4");
+        // 浮点数比较使用近似
+        let temp = value["temperature"].as_f64().unwrap();
+        assert!((temp - 0.7).abs() < 1e-6);
+
+        // 验证 extra_body 消失
+        assert!(value.get("extra_body").is_none());
+    }
+
+    #[test]
+    fn test_responses_request_extra_body_flatten() {
+        use serde_json::json;
+
+        let extra = Some(json!({
+            "reasoning_effort": "high",
+            "parallel_tool_calls": false
+        }));
+
+        let request = ResponsesRequest {
+            model: "gpt-5".to_string(),
+            input: vec![json!({"role": "user", "content": "Hello"})],
+            instructions: None,
+            stream: true,
+            tools: None,
+            reasoning: None,
+            temperature: Some(0.5),
+            extra_body: extra.clone(),
+        };
+
+        let value = serde_json::to_value(&request).unwrap();
+
+        // 验证展平字段
+        assert_eq!(value["reasoning_effort"], "high");
+        assert_eq!(value["parallel_tool_calls"], false);
+
+        // 验证顶层字段
+        assert_eq!(value["model"], "gpt-5");
+        assert_eq!(value["temperature"], 0.5);
+
+        // 验证 extra_body 消失
+        assert!(value.get("extra_body").is_none());
+    }
+
+    #[test]
+    fn test_anthropic_request_extra_body_flatten() {
+        use serde_json::json;
+
+        let extra = Some(json!({
+            "thinking": {
+                "type": "enabled",
+                "budget_tokens": 1024
+            },
+            "metadata": {"user_id": "123"}
+        }));
+
+        let request = AnthropicRequest {
+            model: "claude-3-opus".to_string(),
+            system: Some("You are helpful".to_string()),
+            messages: vec![AnthropicMessage {
+                role: "user".to_string(),
+                content: vec![AnthropicContentBlock::Text {
+                    text: "Hello".to_string(),
+                }],
+            }],
+            tools: None,
+            stream: true,
+            max_tokens: 4096,
+            temperature: Some(0.7),
+            thinking: None,
+            extra_body: extra.clone(),
+        };
+
+        let value = serde_json::to_value(&request).unwrap();
+
+        // 验证展平字段（包括嵌套对象）
+        assert_eq!(value["thinking"]["type"], "enabled");
+        assert_eq!(value["thinking"]["budget_tokens"], 1024);
+        assert_eq!(value["metadata"]["user_id"], "123");
+
+        // 验证顶层字段
+        assert_eq!(value["model"], "claude-3-opus");
+        assert_eq!(value["max_tokens"], 4096);
+
+        // 验证 extra_body 消失
+        assert!(value.get("extra_body").is_none());
+    }
+
+    #[test]
+    fn extra_body_conflict_resolution() {
+        let extra = Some(serde_json::json!({
+            "temperature": 0.9,   // 冲突
+            "model": "gpt-5",     // 冲突
+            "custom": "keep"      // 不冲突
+        }));
+
+        let reserved = vec!["model", "temperature", "stream", "tools"];
+        let sanitized = sanitize_extra_body(extra, &reserved);
+
+        // 由于有非冲突字段 "custom"，sanitized 应为 Some
+        let sanitized_value = sanitized.unwrap();
+        assert!(sanitized_value.get("temperature").is_none());
+        assert!(sanitized_value.get("model").is_none());
+        assert_eq!(sanitized_value["custom"], "keep");
     }
 }
 

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -411,6 +411,7 @@ impl OpenAiCompatibleClient {
             }),
             tools: (!tools.is_empty()).then_some(tools),
             chat_template_kwargs: taotoken_glm_chat_template_kwargs(&self.provider),
+            extra_body: self.provider.extra_body.clone(),
         };
         let url = format!(
             "{}/chat/completions",
@@ -659,6 +660,7 @@ impl OpenAiCompatibleClient {
             max_tokens: self.provider.anthropic_max_tokens,
             temperature: Some(self.provider.temperature),
             thinking: thinking.then(anthropic_thinking_config),
+            extra_body: self.provider.extra_body.clone()
         }
     }
 
@@ -735,6 +737,7 @@ impl OpenAiCompatibleClient {
                 summary: Some("concise"),
             }),
             temperature: Some(self.provider.temperature),
+            extra_body: self.provider.extra_body.clone(),
         };
         let url = format!("{}/responses", self.provider.base_url.trim_end_matches('/'));
         let response = self
@@ -926,6 +929,9 @@ struct ChatRequest {
     tools: Option<Vec<ToolDefinition>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     chat_template_kwargs: Option<ChatTemplateKwargs>,
+    #[serde(flatten)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra_body: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -946,6 +952,9 @@ struct ResponsesRequest {
     reasoning: Option<ResponsesReasoning>,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f32>,
+    #[serde(flatten)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra_body: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -970,6 +979,9 @@ struct AnthropicRequest {
     temperature: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     thinking: Option<AnthropicThinkingConfig>,
+    #[serde(flatten)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    extra_body: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -2731,6 +2743,7 @@ mod tests {
             }),
             tools: None,
             chat_template_kwargs: None,
+            extra_body: None
         };
 
         let value = serde_json::to_value(request).unwrap();

--- a/src/tools/web_images.rs
+++ b/src/tools/web_images.rs
@@ -1973,6 +1973,7 @@ mod tests {
             timeout_seconds: 60,
             temperature: 0.2,
             anthropic_max_tokens: 4096,
+            extra_body: None,
         }
     }
 


### PR DESCRIPTION
## 概述
为 Provider 配置增加 `extra_body` 字段，允许用户自定义任意 JSON 格式的额外参数，并在 LLM 请求体中展平。这解决了 DeepSeek V4 等模型默认启用思考模式、但用户希望关闭的问题，也适用于其他需传递扩展参数的场景（如 `reasoning_effort`、`enable_thinking` 等）。

## 实现内容
- **配置结构 (`config.rs`)**  
  - `ProviderConfig` 新增 `extra_body: Option<serde_json::Value>`，默认 `None`。  
  - 所有构造方法均已补全该字段。

- **LLM 请求构造**  
  - 在 `ChatRequest`、`ResponsesRequest`、`AnthropicRequest` 中增加 `#[serde(flatten)] extra_body`，使其序列化时与顶层字段合并。  
  - 在 `OpenAiCompatibleClient` 的请求构建处，从 `provider.extra_body` 克隆并赋值。

- **TUI 配置界面 (`config_tui.rs`)**  
  - `edit_provider_form` 表单中新增“额外请求体 (JSON)”多行文本域，支持外部编辑器编辑。  
  - 保存时自动校验 JSON 合法性，若格式错误则提示用户重新编辑。

## 向后兼容性
- 现有配置文件不受影响，`extra_body` 缺失时默认 `None`，请求体不发生变化。  
- 代码中所有构造 `ProviderConfig` 的地方均赋予 `None`，保持行为一致。

## 使用示例
在配置文件中为 DeepSeek 显式禁用思考：
```jsonc
{
  "providers": [
    {
      "id": "deepseek",
      "base_url": "https://api.deepseek.com",
      "default_model": "deepseek-v4-flash",
      "extra_body": {
        "thinking": {"type": "enabled"}
      }
    }
  ]
} 
```
## 经过我的测试，deepseek-v4添加字段后能控制是否启用思考以及思考强度 