### PR TITLE
feat: support Shift+Enter newline in REPL

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,10 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 use vte::{Params as VteParams, Parser as VteParser, Perform as VtePerform};
 
+mod keyboard_enhancement;
+
+use keyboard_enhancement::KeyboardEnhancementState;
+
 const REPL_MAX_VISIBLE_INPUT_ROWS: u16 = 12;
 const REPL_PASTE_PLACEHOLDER_MIN_LINES: usize = 3;
 const REPL_PASTE_PLACEHOLDER_MIN_CHARS: usize = 150;
@@ -3750,7 +3754,14 @@ fn print_repl_help() {
         )
     );
     println!("  Enter       {}", t("send message", "发送消息"));
-    println!("  Ctrl+J      {}", t("insert newline", "插入换行"));
+    println!("  Shift+Enter {}", t("insert newline", "插入换行"));
+    println!(
+        "  Ctrl+J      {}",
+        t(
+            "insert newline, same as Shift+Enter",
+            "插入换行，与 Shift+Enter 相同"
+        )
+    );
     println!(
         "  Ctrl+V      {}",
         t(
@@ -3986,6 +3997,12 @@ impl LiveReplEditor {
                     } else {
                         self.cursor = repl_move_cursor_vertical("  ", &self.input, self.cursor, 1);
                     }
+                }
+                KeyCode::Enter if modifiers.contains(KeyModifiers::SHIFT) => {
+                    // Shift+Enter 与 Ctrl+J 相同：在光标处插入换行，不提交
+                    insert_newline_at_cursor(&mut self.input, &mut self.cursor);
+                    self.history_clean_index = None;
+                    self.is_pasted = false;
                 }
                 KeyCode::Enter => {
                     return Ok(self
@@ -4957,31 +4974,52 @@ fn persist_queued_submission(
 struct LiveRawMode {
     show_cursor_on_drop: bool,
     restore_terminal_on_drop: bool,
+    keyboard_enhancement: KeyboardEnhancementState,
 }
 
 struct ReplCursorRestore;
 
 impl Drop for ReplCursorRestore {
     fn drop(&mut self) {
+        // 1. 会话级兜底：恢复括号粘贴与光标
+        // 2. 再关闭 raw mode；键盘增强由 LiveRawMode / 局部输入作用域负责 Pop
         let _ = execute!(io::stdout(), DisableBracketedPaste, Show);
         let _ = terminal::disable_raw_mode();
     }
 }
 
 impl LiveRawMode {
+    /// 进入 live REPL 的 raw 输入模式，并尽量启用键盘增强协议。
+    ///
+    /// 参数: 无
+    ///
+    /// 返回:
+    /// - 成功时返回会在 Drop 时恢复终端的守卫对象
     fn start() -> Result<Self> {
         enable_live_raw_mode()?;
-        execute!(io::stdout(), EnableBracketedPaste)?;
+        let mut stdout = io::stdout();
+        if let Err(error) = execute!(stdout, EnableBracketedPaste) {
+            let _ = terminal::disable_raw_mode();
+            return Err(error.into());
+        }
         Ok(Self {
             show_cursor_on_drop: true,
             restore_terminal_on_drop: true,
+            keyboard_enhancement: KeyboardEnhancementState::enable(&mut stdout),
         })
     }
 
+    /// 接管上一段 live 输入已启用的终端模式，避免重复 Push 键盘增强。
+    ///
+    /// 参数: 无
+    ///
+    /// 返回:
+    /// - 会在最终 Drop 时恢复终端的守卫对象
     fn adopt() -> Self {
         Self {
             show_cursor_on_drop: true,
             restore_terminal_on_drop: true,
+            keyboard_enhancement: KeyboardEnhancementState::assume_active(),
         }
     }
 
@@ -4991,6 +5029,8 @@ impl LiveRawMode {
 
     fn handoff(&mut self) {
         self.restore_terminal_on_drop = false;
+        // handoff 后由下一段 LiveRawMode::adopt 继续持有键盘增强状态
+        self.keyboard_enhancement = KeyboardEnhancementState::default();
     }
 }
 
@@ -5036,6 +5076,9 @@ impl Drop for LiveRawMode {
         } else {
             let _ = execute!(stdout, DisableBracketedPaste);
         }
+        // 1. 先 Pop 键盘增强协议
+        // 2. 再退出 raw mode
+        self.keyboard_enhancement.disable(&mut stdout);
         let _ = terminal::disable_raw_mode();
     }
 }
@@ -5146,6 +5189,7 @@ fn handle_live_agent_event(
                 live.apply_renderer_frame(renderer)?;
                 synchronized_terminal_update(CursorAfterUpdate::Hidden, || live.suspend())?;
                 handle_agent_event(renderer, event)?;
+                // 问题面板只关闭 raw mode 与括号粘贴，键盘增强仍由外层 LiveRawMode 持有
                 enable_live_raw_mode()?;
                 execute!(io::stdout(), EnableBracketedPaste)?;
                 synchronized_terminal_update(CursorAfterUpdate::Shown, || live.resume())?;
@@ -5306,11 +5350,22 @@ fn read_repl_input(
     }
     terminal::enable_raw_mode()?;
     execute!(stdout, EnableBracketedPaste)?;
+    let mut keyboard_enhancement = KeyboardEnhancementState::enable(&mut stdout);
     let (_, mut input_row) = cursor::position()?;
     let mut rendered_rows = 0u16;
     let mut is_pasted = false;
     let mut pasted_images: Vec<Option<crate::clipboard::PastedImage>> = Vec::new();
     let mut pasted_texts: Vec<Option<PastedText>> = Vec::new();
+    // 1. 局部退出时统一恢复终端协议
+    // 2. 避免多处 return 漏 Pop 键盘增强
+    let restore_terminal = |stdout: &mut io::Stdout,
+                            keyboard_enhancement: &mut KeyboardEnhancementState|
+     -> Result<()> {
+        execute!(stdout, DisableBracketedPaste)?;
+        keyboard_enhancement.disable(stdout);
+        terminal::disable_raw_mode()?;
+        Ok(())
+    };
     let render_repl_input = |stdout: &mut io::Stdout,
                              input_row: &mut u16,
                              rendered_rows: &mut u16,
@@ -5512,6 +5567,21 @@ fn read_repl_input(
                         is_pasted,
                     )?;
                 }
+                KeyCode::Enter if modifiers.contains(KeyModifiers::SHIFT) => {
+                    // Shift+Enter 与 Ctrl+J 相同：在光标处插入换行，不提交
+                    insert_newline_at_cursor(&mut input, &mut cursor);
+                    history_clean_index = None;
+                    is_pasted = false;
+                    render_repl_input(
+                        &mut stdout,
+                        &mut input_row,
+                        &mut rendered_rows,
+                        mode,
+                        &input,
+                        cursor,
+                        is_pasted,
+                    )?;
+                }
                 KeyCode::Enter => {
                     let submitted_echo = strip_terminal_control_sequences(&input);
                     input = expand_pasted_text_placeholders(&submitted_echo, &pasted_texts);
@@ -5522,8 +5592,7 @@ fn read_repl_input(
                         mode,
                         &submitted_echo,
                     )?;
-                    execute!(stdout, DisableBracketedPaste)?;
-                    terminal::disable_raw_mode()?;
+                    restore_terminal(&mut stdout, &mut keyboard_enhancement)?;
                     return Ok(Some((mode, input, pasted_images)));
                 }
                 KeyCode::Char('j') if modifiers.contains(KeyModifiers::CONTROL) => {
@@ -5563,16 +5632,14 @@ fn read_repl_input(
                         continue;
                     }
                     move_after_repl_input(&mut stdout, input_row, rendered_rows)?;
-                    execute!(stdout, DisableBracketedPaste)?;
-                    terminal::disable_raw_mode()?;
+                    restore_terminal(&mut stdout, &mut keyboard_enhancement)?;
                     return Ok(None);
                 }
                 KeyCode::Char('d')
                     if modifiers.contains(KeyModifiers::CONTROL) && input.is_empty() =>
                 {
                     move_after_repl_input(&mut stdout, input_row, rendered_rows)?;
-                    execute!(stdout, DisableBracketedPaste)?;
-                    terminal::disable_raw_mode()?;
+                    restore_terminal(&mut stdout, &mut keyboard_enhancement)?;
                     return Ok(None);
                 }
                 KeyCode::Char('l') if modifiers.contains(KeyModifiers::CONTROL) => {
@@ -6020,8 +6087,8 @@ fn input_prompt_bar(mode: AgentMode) -> String {
 fn repl_shortcut_hint_line(mode: AgentMode, cols: usize) -> String {
     let bar = input_prompt_bar(mode);
     let text = t(
-        "Tab switch mode; Ctrl+J newline; Ctrl+V paste clipboard",
-        "Tab 切换模式；Ctrl+J 换行；Ctrl+V 粘贴剪贴板",
+        "Tab switch mode; Shift+Enter newline; Ctrl+J newline; Ctrl+V paste clipboard",
+        "Tab 切换模式；Shift+Enter 换行；Ctrl+J 换行；Ctrl+V 粘贴剪贴板",
     );
     let text_width = cols.saturating_sub(visible_width(&bar)).max(1);
     format!(
@@ -7233,6 +7300,40 @@ mod repl_input_tests {
         assert!(editor.history.is_empty());
         editor.record_history("ordinary prompt");
         assert_eq!(editor.history, ["ordinary prompt"]);
+    }
+
+    #[test]
+    fn live_editor_shift_enter_inserts_newline_without_submit() {
+        let temp = tempfile::tempdir().unwrap();
+        let paths = pop_test_paths(temp.path());
+        let mut editor = LiveReplEditor::new(AgentMode::Normal, Vec::new());
+        editor.input = "hello".to_string();
+        editor.cursor = 5;
+        assert!(matches!(
+            editor
+                .handle_event(
+                    Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT)),
+                    &paths,
+                    false,
+                )
+                .unwrap(),
+            LiveEditorAction::Redraw
+        ));
+        assert_eq!(editor.input, "hello\n");
+        assert_eq!(editor.cursor, 6);
+
+        assert!(matches!(
+            editor
+                .handle_event(
+                    Event::Key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::CONTROL)),
+                    &paths,
+                    false,
+                )
+                .unwrap(),
+            LiveEditorAction::Redraw
+        ));
+        assert_eq!(editor.input, "hello\n\n");
+        assert_eq!(editor.cursor, 7);
     }
 
     #[test]

--- a/src/cli/keyboard_enhancement.rs
+++ b/src/cli/keyboard_enhancement.rs
@@ -1,0 +1,105 @@
+use crossterm::event::{
+    KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+};
+use crossterm::execute;
+use std::io::Write;
+
+/// 键盘增强协议的平台执行策略。
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum KeyboardEnhancementStrategy {
+    BestEffort,
+    Skip,
+}
+
+/// 根据目标平台选择键盘增强协议策略。
+///
+/// 参数:
+/// - `is_windows`: 目标平台是否为 Windows
+///
+/// 返回:
+/// - 目标平台应采用的键盘增强协议策略
+pub(super) const fn strategy_for_platform(is_windows: bool) -> KeyboardEnhancementStrategy {
+    if is_windows {
+        KeyboardEnhancementStrategy::Skip
+    } else {
+        KeyboardEnhancementStrategy::BestEffort
+    }
+}
+
+/// 记录当前终端是否成功启用了键盘增强协议。
+#[derive(Debug, Default)]
+pub(super) struct KeyboardEnhancementState {
+    active: bool,
+}
+
+impl KeyboardEnhancementState {
+    /// 尝试启用键盘增强协议，不支持时保持普通键盘输入。
+    ///
+    /// 参数:
+    /// - `writer`: 接收终端控制序列的输出流
+    ///
+    /// 返回:
+    /// - 是否成功启用协议的状态对象
+    pub(super) fn enable<W: Write>(writer: &mut W) -> Self {
+        if strategy_for_platform(cfg!(windows)) == KeyboardEnhancementStrategy::Skip {
+            return Self::default();
+        }
+
+        let active = execute!(
+            writer,
+            PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+        )
+        .is_ok();
+        Self { active }
+    }
+
+    /// 接管已启用的键盘增强协议，避免 handoff 后重复 Push。
+    ///
+    /// 参数: 无
+    ///
+    /// 返回:
+    /// - 视为已激活的状态对象，Drop/disable 时会 Pop
+    pub(super) fn assume_active() -> Self {
+        if strategy_for_platform(cfg!(windows)) == KeyboardEnhancementStrategy::Skip {
+            return Self::default();
+        }
+        Self { active: true }
+    }
+
+    /// 恢复启用前的键盘增强协议状态。
+    ///
+    /// 参数:
+    /// - `writer`: 接收终端控制序列的输出流
+    ///
+    /// 返回:
+    /// - 无
+    pub(super) fn disable<W: Write>(&mut self, writer: &mut W) {
+        if self.active {
+            let _ = execute!(writer, PopKeyboardEnhancementFlags);
+            self.active = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{strategy_for_platform, KeyboardEnhancementStrategy};
+
+    /// Windows 旧式控制台必须跳过未实现的键盘增强协议。
+    #[test]
+    fn legacy_windows_skips_keyboard_enhancement() {
+        assert_eq!(
+            strategy_for_platform(true),
+            KeyboardEnhancementStrategy::Skip
+        );
+    }
+
+    /// 非 Windows 终端继续以可降级方式启用键盘增强协议。
+    #[test]
+    fn non_windows_uses_best_effort_keyboard_enhancement() {
+        assert_eq!(
+            strategy_for_platform(false),
+            KeyboardEnhancementStrategy::BestEffort
+        );
+    }
+}

--- a/src/question_tui.rs
+++ b/src/question_tui.rs
@@ -7,7 +7,8 @@ use anyhow::{bail, Result};
 use crossterm::cursor::{Hide, MoveTo, Show};
 use crossterm::event::{
     self, DisableBracketedPaste, EnableBracketedPaste, Event, KeyCode, KeyEvent, KeyEventKind,
-    KeyModifiers,
+    KeyModifiers, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
+    PushKeyboardEnhancementFlags,
 };
 use crossterm::terminal::{self, Clear, ClearType};
 use crossterm::{execute, queue};
@@ -267,6 +268,10 @@ fn handle_editing_key(
         KeyCode::Char('j') if key.modifiers.contains(KeyModifiers::CONTROL) => {
             insert_text(&mut state.edit_buffer, &mut state.edit_cursor, "\n");
         }
+        KeyCode::Enter if key.modifiers.contains(KeyModifiers::SHIFT) => {
+            // Shift+Enter 与 Ctrl+J 相同：自定义答案编辑时插入换行
+            insert_text(&mut state.edit_buffer, &mut state.edit_cursor, "\n");
+        }
         KeyCode::Esc => {
             state.editing = false;
             state.edit_buffer.clear();
@@ -352,6 +357,7 @@ struct QuestionSession {
     stdout: io::Stdout,
     anchor_y: u16,
     panel_lines: u16,
+    keyboard_enhancement_active: bool,
 }
 
 impl QuestionSession {
@@ -363,6 +369,17 @@ impl QuestionSession {
             let _ = terminal::disable_raw_mode();
             return Err(err.into());
         }
+        // 1. 尽量启用键盘增强，使 Shift+Enter 可被识别
+        // 2. Windows 旧控制台可能不支持，失败时仍保持普通输入
+        let keyboard_enhancement_active = if cfg!(windows) {
+            false
+        } else {
+            execute!(
+                stdout,
+                PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+            )
+            .is_ok()
+        };
         let (_, cursor_y) =
             crossterm::cursor::position().unwrap_or((0, panel_lines.saturating_sub(1)));
         let anchor_y = cursor_y.saturating_sub(panel_lines.saturating_sub(1));
@@ -370,6 +387,7 @@ impl QuestionSession {
             stdout,
             anchor_y,
             panel_lines,
+            keyboard_enhancement_active,
         })
     }
 
@@ -488,7 +506,14 @@ impl QuestionSession {
 
 impl Drop for QuestionSession {
     fn drop(&mut self) {
+        // 1. 恢复括号粘贴与光标
+        // 2. 若启用过键盘增强则 Pop
+        // 3. 退出 raw mode
         let _ = execute!(self.stdout, DisableBracketedPaste, Show);
+        if self.keyboard_enhancement_active {
+            let _ = execute!(self.stdout, PopKeyboardEnhancementFlags);
+            self.keyboard_enhancement_active = false;
+        }
         let _ = terminal::disable_raw_mode();
     }
 }
@@ -591,8 +616,8 @@ fn draw(
             footer_lines.push(format!(
                 "\x1b[2m{}\x1b[0m",
                 t(
-                    "Enter save · Ctrl+J newline · Esc stop editing",
-                    "Enter 保存 · Ctrl+J 换行 · Esc 退出编辑"
+                    "Enter save · Shift+Enter newline · Ctrl+J newline · Esc stop editing",
+                    "Enter 保存 · Shift+Enter 换行 · Ctrl+J 换行 · Esc 退出编辑"
                 )
             ));
         } else {
@@ -1146,6 +1171,7 @@ mod tests {
             stdout: io::stdout(),
             anchor_y: 8,
             panel_lines: 12,
+            keyboard_enhancement_active: false,
         });
         session.resize_to_terminal(3);
         assert_eq!(session.panel_lines, 2);
@@ -1196,6 +1222,30 @@ mod tests {
             &request,
             &mut state,
             KeyEvent::new(KeyCode::Char('j'), KeyModifiers::CONTROL),
+        )
+        .unwrap();
+        assert_eq!(state.edit_buffer, "前\n");
+    }
+
+    #[test]
+    fn shift_enter_inserts_custom_answer_newline() {
+        let request = QuestionRequest {
+            questions: vec![QuestionPrompt {
+                header: "说明".to_string(),
+                question: "补充说明".to_string(),
+                options: Vec::new(),
+                multiple: false,
+                custom: true,
+            }],
+        };
+        let mut state = QuestionState::new(&request);
+        state.editing = true;
+        state.edit_buffer = "前".to_string();
+        state.edit_cursor = 1;
+        handle_editing_key(
+            &request,
+            &mut state,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::SHIFT),
         )
         .unwrap();
         assert_eq!(state.edit_buffer, "前\n");


### PR DESCRIPTION
## Summary
- Enable keyboard enhancement protocol so terminals can report `Shift+Enter`
- Treat `Shift+Enter` the same as `Ctrl+J` for multi-line input in live/classic REPL and question editing
- Update help/hint copy and add unit coverage for the new key path

## Test plan
- [x] `cargo test live_editor_shift_enter`
- [x] `cargo test shift_enter_inserts_custom_answer_newline`
- [x] `cargo test ctrl_j_inserts_custom_answer_newline`
- [x] `cargo test keyboard_enhancement`
- [x] Manual: in interactive REPL, `Shift+Enter` inserts newline and `Enter` still submits
- [x] Manual: question custom answer editor accepts `Shift+Enter` newline