### PR TITLE
feat: add Nushell shell integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,19 @@ Miyu 是从我曾经很喜欢的动画中的角色[久遠寺未有](http://www.m
 
 ## 有什么功能？
 
-`miyu` 由大模型驱动，默认接入了 [opencode](https://github.com/anomalyco/opencode) 的公共模型服务，你也可以配置自己的大模型服务。她并非专业的 Coding Agent，而是更偏向聊天日常、游戏娱乐、系统排障等日用场景。并且 `miyu` 还可以无缝与 `fish`、`zsh`、`bash` 集成，终端打字直接无缝对话！
+`miyu` 由大模型驱动，默认接入了 [opencode](https://github.com/anomalyco/opencode) 的公共模型服务，你也可以配置自己的大模型服务。她并非专业的 Coding Agent，而是更偏向聊天日常、游戏娱乐、系统排障等日用场景。并且 `miyu` 还可以与 `fish`、`zsh`、`bash` 和 Nushell 集成，在终端中直接对话！
 
 ![](./pics/shell-init.png)
+
+### Nushell 集成
+
+Nushell 用户可以运行：
+
+```nu
+miyu nu-init
+```
+
+重启 Nushell（或按命令提示重新加载 hook）后，在命令行输入消息并按 `Alt+M` 即可发送给 Miyu。普通 `Enter` 不会被重绑定，Nushell 的原生命令执行、历史、提示符和行编辑行为保持不变。`miyu remove-shell-hook` 可以安全移除该集成。
 
 `miyu` 还自带了 TUI 方便修改配置。
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -483,6 +483,11 @@ fn localize_subcommands(mut command: clap::Command) -> clap::Command {
             "集成到 zsh，集成后可在终端直接使用自然语言交流。",
         ),
         (
+            "nu-init",
+            "Integrate with Nushell; press Alt+M to send the current command line to Miyu",
+            "集成到 Nushell；按 Alt+M 将当前命令行发送给 Miyu。",
+        ),
+        (
             "remove-shell-hook",
             "Safely remove installed Miyu shell hooks",
             "安全删除已安装的 Miyu shell hook",
@@ -742,6 +747,7 @@ pub enum Command {
     FishInit,
     BashInit,
     ZshInit,
+    NuInit,
     RemoveShellHook,
     History(HistoryArgs),
     Pop(PopArgs),
@@ -1033,6 +1039,7 @@ pub async fn run(cli: Cli, paths: MiyuPaths) -> Result<()> {
                 | Some(Command::FishInit)
                 | Some(Command::BashInit)
                 | Some(Command::ZshInit)
+                | Some(Command::NuInit)
                 | Some(Command::RemoveShellHook)
                 | Some(Command::Paths)
         )
@@ -1057,6 +1064,7 @@ pub async fn run(cli: Cli, paths: MiyuPaths) -> Result<()> {
         Some(Command::FishInit) => shell::fish::install(&paths),
         Some(Command::BashInit) => shell::bash::install(&paths),
         Some(Command::ZshInit) => shell::zsh::install(&paths),
+        Some(Command::NuInit) => shell::nu::install(&paths),
         Some(Command::RemoveShellHook) => remove_shell_hooks(&paths),
         Some(Command::History(args)) => run_history(&paths, args),
         Some(Command::Pop(args)) => run_pop(&paths, args),
@@ -1184,6 +1192,7 @@ fn prompt_shell_init_menu(paths: &MiyuPaths) -> Result<()> {
         Some("fish") => shell::fish::install(paths),
         Some("bash") => shell::bash::install(paths),
         Some("zsh") => shell::zsh::install(paths),
+        Some("nu") => shell::nu::install(paths),
         _ => Ok(()),
     }
 }
@@ -1194,6 +1203,7 @@ fn select_shell_hook() -> Result<Option<&'static str>> {
         ("fish", Some("fish")),
         ("bash", Some("bash")),
         ("zsh", Some("zsh")),
+        ("nushell (Alt+M)", Some("nu")),
     ];
     let detected = shell::current_parent_shell();
     let mut selected = detected
@@ -1266,6 +1276,7 @@ fn remove_shell_hooks(paths: &MiyuPaths) -> Result<()> {
     let removed = shell::fish::uninstall(paths)?;
     let removed = shell::bash::uninstall(paths)? || removed;
     let removed = shell::zsh::uninstall(paths)? || removed;
+    let removed = shell::nu::uninstall(paths)? || removed;
     if !removed {
         println!(
             "{}",
@@ -2271,7 +2282,7 @@ fn run_shell_classify(shell_name: &str, message: &str) -> Result<()> {
 }
 
 async fn run_shell_intercept(paths: &MiyuPaths, shell_name: &str, message: String) -> Result<()> {
-    if !matches!(shell_name, "fish" | "bash" | "zsh") {
+    if !matches!(shell_name, "fish" | "bash" | "zsh" | "nu") {
         bail!("{}: {shell_name}", t("unsupported shell", "不支持的 shell"));
     }
     if message.trim().is_empty() {
@@ -6834,6 +6845,12 @@ mod repl_input_tests {
                 .to_vec()
         )
         .is_err());
+    }
+
+    #[test]
+    fn nu_init_is_a_cli_subcommand() {
+        let cli = parse_args(["miyu", "nu-init"].map(OsString::from).to_vec()).unwrap();
+        assert!(matches!(cli.command, Some(Command::NuInit)));
     }
 
     #[test]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -74,6 +74,10 @@ impl MiyuPaths {
         self.cache_dir.join("logs")
     }
 
+    pub fn nu_hook_file(&self) -> PathBuf {
+        self.config_dir.join("shell/nu-hook.nu")
+    }
+
     pub fn print(&self) {
         println!(
             "{}: {}",
@@ -129,6 +133,11 @@ impl MiyuPaths {
             "{}: {}",
             t("zsh hook file", "zsh hook 文件"),
             self.zsh_hook_file.display()
+        );
+        println!(
+            "{}: {}",
+            t("nushell hook file", "nushell hook 文件"),
+            self.nu_hook_file().display()
         );
         println!(
             "{}: {}",

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1,5 +1,6 @@
 pub mod bash;
 pub mod fish;
+pub mod nu;
 pub mod zsh;
 
 use crate::i18n::text as t;
@@ -12,6 +13,7 @@ pub fn print_reload_hint(shell: &str, hook_file: &Path) {
     let source = match shell {
         "fish" => format!("source {}", fish_quote(hook_file)),
         "bash" | "zsh" => format!("source {}", shell_quote(hook_file)),
+        "nu" => format!("source {}", nu_quote(hook_file)),
         _ => return,
     };
     if current_parent_shell().as_deref() == Some(shell) {
@@ -39,7 +41,7 @@ pub fn current_parent_shell() -> Option<String> {
     for _ in 0..8 {
         let parent = parent_pid(pid)?;
         let name = process_name(parent)?;
-        if matches!(name.as_str(), "fish" | "bash" | "zsh") {
+        if matches!(name.as_str(), "fish" | "bash" | "zsh" | "nu") {
             return Some(name);
         }
         pid = parent;
@@ -72,6 +74,10 @@ fn fish_quote(path: &Path) -> String {
             .replace('\\', "\\\\")
             .replace('\'', "\\'")
     )
+}
+
+fn nu_quote(path: &Path) -> String {
+    serde_json::to_string(&path.to_string_lossy()).expect("serializing a path string cannot fail")
 }
 
 #[cfg(test)]

--- a/src/shell/nu.rs
+++ b/src/shell/nu.rs
@@ -1,0 +1,215 @@
+use crate::i18n::text as t;
+use crate::paths::MiyuPaths;
+use anyhow::Result;
+use directories::BaseDirs;
+use std::path::{Path, PathBuf};
+
+const BEGIN_MARKER: &str = "# >>> miyu nushell hook >>>";
+const END_MARKER: &str = "# <<< miyu nushell hook <<<";
+
+pub fn hook() -> &'static str {
+    r#"# Send the current Nushell command line to Miyu with Alt+M.
+# Enter remains untouched so native commands, history, and input editing keep
+# using Nushell's normal Reedline flow.
+def __miyu_send_buffer [] {
+    let message = (commandline)
+    if ($message | str trim | is-empty) {
+        return
+    }
+
+    commandline edit --replace ""
+    $message | ^miyu --shell-intercept --shell nu --stdin
+}
+
+$env.config.keybindings = (
+    $env.config.keybindings
+    | where name != "miyu_send_buffer"
+    | append {
+        name: miyu_send_buffer
+        modifier: alt
+        keycode: char_m
+        mode: [emacs vi_insert vi_normal]
+        event: {
+            send: executehostcommand
+            cmd: "__miyu_send_buffer"
+        }
+    }
+)
+"#
+}
+
+pub fn install(paths: &MiyuPaths) -> Result<()> {
+    let hook_file = paths.nu_hook_file();
+    let config_file = nushell_config_file();
+    install_to(&hook_file, &config_file)?;
+
+    println!(
+        "{}: {}",
+        t("installed nushell hook", "已安装 nushell hook"),
+        hook_file.display()
+    );
+    println!("{}: {}", t("updated", "已更新"), config_file.display());
+    super::print_reload_hint("nu", &hook_file);
+    Ok(())
+}
+
+pub fn uninstall(paths: &MiyuPaths) -> Result<bool> {
+    let hook_file = paths.nu_hook_file();
+    let config_file = nushell_config_file();
+    let removed_block = remove_source_block(&config_file)?;
+    let removed_file = remove_file_if_exists(&hook_file)?;
+    let removed = removed_block || removed_file;
+    if removed {
+        println!(
+            "{}: nushell",
+            t("removed Miyu shell hook", "已移除 Miyu shell hook")
+        );
+    }
+    Ok(removed)
+}
+
+fn nushell_config_file() -> PathBuf {
+    BaseDirs::new()
+        .map(|base| base.config_dir().join("nushell/config.nu"))
+        .unwrap_or_else(|| PathBuf::from(".config/nushell/config.nu"))
+}
+
+fn install_to(hook_file: &Path, config_file: &Path) -> Result<()> {
+    if let Some(parent) = hook_file.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(hook_file, hook())?;
+    append_source_block(config_file, hook_file)
+}
+
+fn append_source_block(config_file: &Path, hook_file: &Path) -> Result<()> {
+    let existing = std::fs::read_to_string(config_file).unwrap_or_default();
+    if existing.contains(BEGIN_MARKER) && existing.contains(END_MARKER) {
+        return Ok(());
+    }
+    if let Some(parent) = config_file.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let mut updated = existing;
+    if !updated.is_empty() && !updated.ends_with('\n') {
+        updated.push('\n');
+    }
+    if !updated.is_empty() {
+        updated.push('\n');
+    }
+    updated.push_str(BEGIN_MARKER);
+    updated.push('\n');
+    updated.push_str("source ");
+    updated.push_str(&nu_quote(hook_file));
+    updated.push('\n');
+    updated.push_str(END_MARKER);
+    updated.push('\n');
+    std::fs::write(config_file, updated)?;
+    Ok(())
+}
+
+fn remove_source_block(config_file: &Path) -> Result<bool> {
+    let Ok(existing) = std::fs::read_to_string(config_file) else {
+        return Ok(false);
+    };
+    let Some(begin_index) = existing.find(BEGIN_MARKER) else {
+        return Ok(false);
+    };
+    let Some(end_relative) = existing[begin_index..].find(END_MARKER) else {
+        return Ok(false);
+    };
+
+    let mut start_index = begin_index;
+    if start_index > 0 && existing.as_bytes().get(start_index - 1) == Some(&b'\n') {
+        start_index -= 1;
+    }
+    let mut end_index = begin_index + end_relative + END_MARKER.len();
+    if existing.as_bytes().get(end_index) == Some(&b'\r') {
+        end_index += 1;
+    }
+    if existing.as_bytes().get(end_index) == Some(&b'\n') {
+        end_index += 1;
+    }
+
+    let mut updated = String::new();
+    updated.push_str(&existing[..start_index]);
+    updated.push_str(&existing[end_index..]);
+    std::fs::write(config_file, updated)?;
+    Ok(true)
+}
+
+fn remove_file_if_exists(path: &Path) -> Result<bool> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn nu_quote(path: &Path) -> String {
+    serde_json::to_string(&path.to_string_lossy()).expect("serializing a path string cannot fail")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hook_uses_alt_m_without_rebinding_enter() {
+        let generated = hook();
+        assert!(generated.contains("modifier: alt"));
+        assert!(generated.contains("keycode: char_m"));
+        assert!(generated.contains("commandline"));
+        assert!(generated.contains("commandline edit --replace \"\""));
+        assert!(generated.contains("--shell-intercept --shell nu --stdin"));
+        assert!(generated.contains("where name != \"miyu_send_buffer\""));
+        assert!(!generated.contains("keycode: enter"));
+        assert!(!generated.contains("command_not_found"));
+        assert!(!generated.contains("history import"));
+    }
+
+    #[test]
+    fn install_is_idempotent_and_preserves_existing_config() {
+        let temp = tempfile::tempdir().unwrap();
+        let hook_file = temp.path().join("miyu/shell/nu-hook.nu");
+        let config_file = temp.path().join("nushell/config.nu");
+        std::fs::create_dir_all(config_file.parent().unwrap()).unwrap();
+        std::fs::write(&config_file, "$env.TEST = 'kept'\n").unwrap();
+
+        install_to(&hook_file, &config_file).unwrap();
+        install_to(&hook_file, &config_file).unwrap();
+
+        let config = std::fs::read_to_string(&config_file).unwrap();
+        assert!(config.contains("$env.TEST = 'kept'"));
+        assert_eq!(config.matches(BEGIN_MARKER).count(), 1);
+        assert_eq!(config.matches(END_MARKER).count(), 1);
+        assert!(config.contains(&nu_quote(&hook_file)));
+        assert_eq!(std::fs::read_to_string(&hook_file).unwrap(), hook());
+    }
+
+    #[test]
+    fn uninstall_removes_only_the_managed_block_and_hook() {
+        let temp = tempfile::tempdir().unwrap();
+        let hook_file = temp.path().join("miyu/shell/nu-hook.nu");
+        let config_file = temp.path().join("nushell/config.nu");
+        std::fs::create_dir_all(config_file.parent().unwrap()).unwrap();
+        std::fs::write(&config_file, "before\nafter\n").unwrap();
+        install_to(&hook_file, &config_file).unwrap();
+
+        assert!(remove_source_block(&config_file).unwrap());
+        assert!(remove_file_if_exists(&hook_file).unwrap());
+        assert_eq!(
+            std::fs::read_to_string(&config_file).unwrap(),
+            "before\nafter\n"
+        );
+        assert!(!remove_source_block(&config_file).unwrap());
+        assert!(!remove_file_if_exists(&hook_file).unwrap());
+    }
+
+    #[test]
+    fn nu_quote_handles_spaces_quotes_and_non_ascii_paths() {
+        let quoted = nu_quote(Path::new("/tmp/Miyu 配置/it's/hook.nu"));
+        assert_eq!(quoted, "\"/tmp/Miyu 配置/it's/hook.nu\"");
+    }
+}


### PR DESCRIPTION
## Summary

- add `miyu nu-init` and a managed Nushell hook sourced from `config.nu`
- bind `Alt+M` through the public Reedline keybinding API while leaving Enter untouched
- send the complete UTF-8 command line through stdin to `miyu --shell-intercept --shell nu --stdin`
- add Nushell detection, initialization menu/help text, safe idempotent uninstall, tests, and README documentation

## Why Alt+M

Nushell does not provide a non-invasive `command_not_found` path that can both capture the original full line and suppress the native error. Rebinding Enter would affect ordinary command execution, history, aliases, custom commands, prompts, and input methods. A dedicated `Alt+M` binding makes the chat action explicit and keeps native Enter behavior unchanged.

The hook removes an existing Miyu binding by name before appending it, so sourcing the configuration repeatedly does not accumulate bindings. It does not call `history import`: Nushell 0.114.1 creates a backup file for each import, which is unsuitable for per-message use. Miyu still records the message in its own conversation history.

## User impact

Run `miyu nu-init`, reload the hook, type a message, and press `Alt+M`. Empty input is ignored, the editor buffer is cleared, and quotes, pipes, dollar signs, spaces, and Chinese text are passed without secondary shell parsing. `miyu remove-shell-hook` removes only the managed block and hook file.

No Nushell source code or binary changes are required.

## Validation

- `cargo fmt --all -- --check`
- Nushell hook and CLI unit tests: 5 passed
- isolated XDG lifecycle: `nu-init -> source twice -> remove-shell-hook`
- Nushell 0.114.1: one Miyu binding after repeated source, no Enter binding
- manual interactive test: Chinese text, spaces, quotes, pipes, and `$` passed through Alt+M; ordinary Enter remained native
- `cargo clippy --locked --all-targets` passed (upstream warnings remain)
- `cargo build --release --locked` passed
- `cargo test --locked`: 590 passed, 3 ignored, 2 failed; both failures reproduce unchanged on upstream `main` at `da1ff66`:
  - `llm::openai_compatible::tests::fully_empty_stream_result_is_rejected`
  - `token_estimate::tests::counts_match_official_tiktoken_vectors`
