### PR TITLE
fix(web): WebUI 默认绑定 127.0.0.1，避免局域网无认证暴露

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ miyu config
   miyu
   ```
 
-- webui 局域网网页
+- webui 网页（默认仅本机 `127.0.0.1` 可访问；需要局域网访问时加 `--bind 0.0.0.0` 并务必设置密码）
 
   ```
   miyu web

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1051,7 +1051,7 @@ pub struct WebArgs {
     #[arg(long, default_value_t = ipc::DEFAULT_WEB_PORT)]
     pub port: u16,
 
-    /// WebUI 监听地址；默认 0.0.0.0（所有网卡），127.0.0.1 仅限本机访问。
+    /// WebUI 监听地址；默认 127.0.0.1（仅限本机），0.0.0.0 显式开放局域网访问。
     #[arg(long, value_name = "ADDR")]
     pub bind: Option<std::net::IpAddr>,
 
@@ -1595,7 +1595,7 @@ fn web_launch_config(paths: &MiyuPaths, args: &WebArgs) -> Result<Option<ipc::Da
 fn daemon_web_access_urls(info: &ipc::DaemonInfo) -> Vec<String> {
     let bind = info
         .web_bind
-        .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
+        .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
     ipc::web_access_urls_for(bind, info.web_port)
 }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -76,7 +76,7 @@ pub struct DaemonLaunchConfig {
     pub port: u16,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub password_file: Option<PathBuf>,
-    /// WebUI bind address; `None` keeps the historical 0.0.0.0 default.
+    /// WebUI bind address; `None` binds loopback only (the secure default).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bind: Option<std::net::IpAddr>,
 }
@@ -783,7 +783,8 @@ fn recover_legacy_daemon_launch_from_cmdline(
     Ok(DaemonLaunchConfig {
         port: parsed.port,
         password_file,
-        // Legacy daemons predate --bind, so they were listening on 0.0.0.0.
+        // Legacy daemons predate --bind and listened on 0.0.0.0; recovery
+        // now leaves the (secure) loopback default in place.
         bind: None,
     })
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -1772,10 +1772,10 @@ pub async fn run(paths: MiyuPaths, args: WebArgs) -> Result<()> {
     }
     let context = cold_context(&config, &state_store)?;
 
-    // Default binds all interfaces so the WebUI is reachable from the LAN;
-    // `--bind 127.0.0.1` restricts it to this machine. Access URLs matching
-    // the effective bind are printed below.
-    let bind_ip = args.bind.unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+    // Default binds loopback only so an unauthenticated WebUI is never
+    // exposed to the LAN; `--bind 0.0.0.0` opts back in explicitly. Access
+    // URLs matching the effective bind are printed below.
+    let bind_ip = args.bind.unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST));
     let listener = match tokio::net::TcpListener::bind(SocketAddr::new(bind_ip, args.port)).await {
         Ok(listener) => listener,
         Err(error)


### PR DESCRIPTION
此前 daemon 默认 0.0.0.0 且无密码，局域网内任意设备可无认证访问
WebUI 的全部工具（含默认开启的命令执行）。现默认仅回环监听，
--bind 0.0.0.0 显式开放局域网；同步更新帮助文本、URL 兜底
与 README 说明。