### PR TITLE
fix: 修复内存泄漏与TUI挂断空转

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9271,6 +9271,11 @@ impl LiveReplEditor {
 
     fn record_history(&mut self, content: &str) {
         self.history.push(content.to_string());
+        const REPL_HISTORY_LIMIT: usize = 500;
+        if self.history.len() > REPL_HISTORY_LIMIT {
+            let excess = self.history.len() - REPL_HISTORY_LIMIT;
+            self.history.drain(..excess);
+        }
         self.history_index = self.history.len();
     }
 
@@ -10902,6 +10907,19 @@ struct SharedJobsFeed {
     rendered_turns: std::sync::Mutex<std::collections::HashSet<String>>,
 }
 
+/// Cap for the dedup bookkeeping sets in [`SharedJobsFeed`]. They only
+/// suppress double-follow / double-render; dropping old ids is harmless and
+/// keeps long-lived REPLs from accumulating an unbounded set.
+const JOBS_FEED_MARK_LIMIT: usize = 4096;
+
+fn mark_with_cap(set: &std::sync::Mutex<std::collections::HashSet<String>>, id: &str) {
+    let mut set = set.lock().unwrap();
+    if set.len() >= JOBS_FEED_MARK_LIMIT {
+        set.clear();
+    }
+    set.insert(id.to_string());
+}
+
 #[derive(Clone)]
 struct BackgroundReport {
     turn_id: String,
@@ -10969,6 +10987,9 @@ impl JobsFeed {
         let mut followed = shared.followed_runs.lock().unwrap();
         for (run_id, run_session, label) in wake_runs.iter() {
             if run_session == session && !followed.contains(run_id) {
+                if followed.len() >= JOBS_FEED_MARK_LIMIT {
+                    followed.clear();
+                }
                 followed.insert(run_id.clone());
                 return Some((run_id.clone(), label.clone()));
             }
@@ -11529,11 +11550,7 @@ async fn follow_wake_run(
     live.raw_mode_handoff = true;
     // Suppress the duplicate DB report for a turn that was rendered live.
     if let Some(turn_id) = turn_id {
-        jobs_shared
-            .rendered_turns
-            .lock()
-            .unwrap()
-            .insert(turn_id);
+        mark_with_cap(&jobs_shared.rendered_turns, &turn_id);
     }
     Ok(())
 }

--- a/src/config_tui.rs
+++ b/src/config_tui.rs
@@ -8126,6 +8126,18 @@ fn read_key() -> Result<KeyCode> {
 
 fn read_key_with_timeout(timeout: Option<Duration>) -> Result<Option<KeyCode>> {
     loop {
+        // PTY 对端关闭后 crossterm 的 poll/read 会空转,用裸 poll 探测 HUP 兜底。
+        let mut pollfd = libc::pollfd {
+            fd: libc::STDIN_FILENO,
+            events: 0,
+            revents: 0,
+        };
+        let ready = unsafe { libc::poll(&mut pollfd, 1, 0) };
+        if ready == 1
+            && (pollfd.revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL)) != 0
+        {
+            std::process::exit(1);
+        }
         if let Some(timeout) = timeout {
             if !event::poll(timeout)? {
                 return Ok(None);

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -190,6 +190,9 @@ impl MessageActivityHandle {
         state.total_messages = state.total_messages.saturating_add(1);
         let total_messages = state.total_messages;
         let sender_messages = {
+            if state.sender_messages.len() >= MESSAGE_ACTIVITY_SEEN_LIMIT {
+                state.sender_messages.clear();
+            }
             let count = state
                 .sender_messages
                 .entry(sender_id.to_string())

--- a/src/question_tui.rs
+++ b/src/question_tui.rs
@@ -53,6 +53,19 @@ pub fn ask(request: &QuestionRequest) -> Result<QuestionResponse> {
     let mut state = QuestionState::new(request);
 
     loop {
+        // PTY 对端关闭时 crossterm 的 poll 会永远立即就绪但读不出事件,
+        // 导致主循环全速空转。用裸 poll 探测 HUP,挂了直接退出。
+        let mut pollfd = libc::pollfd {
+            fd: libc::STDIN_FILENO,
+            events: 0,
+            revents: 0,
+        };
+        let ready = unsafe { libc::poll(&mut pollfd, 1, 0) };
+        if ready == 1
+            && (pollfd.revents & (libc::POLLHUP | libc::POLLERR | libc::POLLNVAL)) != 0
+        {
+            std::process::exit(1);
+        }
         if state
             .cancel_armed_until
             .is_some_and(|deadline| Instant::now() >= deadline)

--- a/src/tools/jobs.rs
+++ b/src/tools/jobs.rs
@@ -233,11 +233,14 @@ pub fn overview() -> Vec<JobOverview> {
     rows.into_iter().map(overview_of).collect()
 }
 
-/// Mark a finished job as reported; it disappears from the overview.
+/// Mark a finished job as reported; it disappears from the overview and its
+/// registry entry is freed so long-running daemons do not accumulate an
+/// unbounded number of terminal jobs in memory.
 pub fn acknowledge(job_id: &str) {
-    if let Some(job) = jobs().lock().unwrap().get_mut(job_id) {
+    let mut jobs = jobs().lock().unwrap();
+    if let Some(job) = jobs.get(job_id) {
         if job.state.is_terminal() {
-            job.acknowledged = true;
+            jobs.remove(job_id);
         }
     }
 }

--- a/src/tools/weather.rs
+++ b/src/tools/weather.rs
@@ -17,6 +17,9 @@ const OPEN_METEO_CLIMATE_URL: &str = "https://climate-api.open-meteo.com/v1/clim
 const OPEN_METEO_ELEVATION_URL: &str = "https://api.open-meteo.com/v1/elevation";
 const GEOCODING_CACHE_TTL: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 const FORECAST_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
+/// Retained entries older than this are swept on every write so the caches
+/// never grow without bound on long-running daemons.
+const WEATHER_CACHE_TTL_MAX: Duration = Duration::from_secs(8 * 24 * 60 * 60);
 
 pub fn register(registry: &mut ToolRegistry) {
     registry.register(ToolSpec::new(
@@ -671,6 +674,7 @@ fn read_cache<T: Clone>(
 
 fn write_cache<T>(cache: &Mutex<HashMap<String, CacheEntry<T>>>, key: String, value: T) {
     if let Ok(mut cache) = cache.lock() {
+        cache.retain(|_, entry| entry.inserted_at.elapsed() <= WEATHER_CACHE_TTL_MAX);
         cache.insert(
             key,
             CacheEntry {


### PR DESCRIPTION
Miyu 自查发现的几处内存与 CPU 问题:

1. **jobs.rs**: 后台任务注册表只增不删, daemon 长期运行内存线性增长; acknowledge 后释放终态条目
2. **cli.rs**: REPL 历史无上限; jobs feed 去重集合无清理
3. **platforms/mod.rs**: sender_messages 无上限
4. **weather.rs**: 缓存过期条目不回收
5. **question_tui/config_tui**: 缺 PTY 挂断检测, 终端关闭后进程 100% CPU 空转

全部通过 cargo check。