### PR TITLE
ci: 添加多平台测试矩阵与自动化 Release 工作流

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  code-quality:
+    name: Code Quality & Safety Net
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Check model-facing text (No CJK in descriptions)
+        run: bash test_scripts/check-model-english.sh
+
+      - name: Check architectural dependencies
+        run: python3 test_scripts/arch_dep_check.py --warn
+
+      - name: File size audit report
+        run: python3 test_scripts/refactor_size_report.py
+
+  build-and-test:
+    name: Build & Test (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            name: Linux-x86_64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            name: macOS-Apple-Silicon
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev pkg-config
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Check all targets
+        run: cargo check --all-targets --target ${{ matrix.target }}
+
+      - name: Run unit tests
+        run: cargo test --lib --no-fail-fast

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,126 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name to release (e.g. v0.5.1)'
+        required: true
+        default: 'v0.5.1'
+
+permissions:
+  contents: write
+
+jobs:
+  build-binaries:
+    name: Build Binary (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            name: linux-x86_64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            name: macos-arm64
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            name: macos-x86_64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine version tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag_name }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
+
+      - name: Install Linux system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev pkg-config
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Package release archive
+        shell: bash
+        run: |
+          ARCHIVE_DIR="miyu-${{ env.RELEASE_TAG }}-${{ matrix.name }}"
+          mkdir -p "${ARCHIVE_DIR}"
+
+          # Copy main binary
+          cp "target/${{ matrix.target }}/release/miyu" "${ARCHIVE_DIR}/"
+
+          # Copy project metadata & assets
+          cp README.md LICENSE "${ARCHIVE_DIR}/" || true
+          [ -d kb ] && cp -r kb "${ARCHIVE_DIR}/" || true
+          [ -d assets ] && cp -r assets "${ARCHIVE_DIR}/" || true
+          [ -d src/memes ] && mkdir -p "${ARCHIVE_DIR}/memes" && cp -r src/memes/miyu "${ARCHIVE_DIR}/memes/" || true
+          [ -d src/scripts ] && mkdir -p "${ARCHIVE_DIR}/scripts" && cp -r src/scripts "${ARCHIVE_DIR}/" || true
+
+          # Create tar.gz
+          tar -czvf "${ARCHIVE_DIR}.tar.gz" "${ARCHIVE_DIR}"
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: miyu-${{ env.RELEASE_TAG }}-${{ matrix.name }}.tar.gz
+
+  publish-release:
+    name: Publish GitHub Release
+    needs: [build-binaries]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine version tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag_name }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare release assets and checksums
+        run: |
+          mkdir -p release-assets
+          find artifacts -type f -name "*.tar.gz" -exec cp {} release-assets/ \;
+
+          cd release-assets
+          sha256sum *.tar.gz > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Create or update GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: "Miyu ${{ env.RELEASE_TAG }}"
+          files: |
+            release-assets/*
+          draft: false
+          prerelease: false
+          generate_release_notes: true


### PR DESCRIPTION
### PR 描述:
#### 背景与动机
目前 Miyu 的构建发布主要依赖作者本地 Arch Linux 物理机手工打包（`makepkg` + `gh release create`），且 todolist 中存在「MacOS 适配」与跨平台分发需求。

本 PR 为项目引入无侵入的 GitHub Actions 自动化体系：
1. **CI 门禁 (`.github/workflows/ci.yml`)**：
   - 自动集成现有的安全网（`check-model-english.sh`、`arch_dep_check.py` 等）；
   - 构建矩阵覆盖 `Linux x86_64` 与 `macOS aarch64`，提交 PR 时自动执行 `cargo check` 与单元测试。
2. **全端发布流 (`.github/workflows/release.yml`)**：
   - 当推送 `v*` 标签时，自动并行构建 Linux x86_64、macOS Apple Silicon 和 macOS Intel 三大架构 Release 资产；
   - 严格遵循 `packaging/README.md` 资产约定，自动打包 `kb/`、`assets/`、`memes/` 与 `scripts/`；
   - 自动计算 `SHA256SUMS.txt` 并挂载至 GitHub Release，解放本地发版劳动力。

#### 验证记录
- 在个人 Fork 仓库已全绿跑通多端 CI 与代码合规门禁：
  Run 验证链接: https://github.com/yxxbc/Miyu/actions/runs/34471295122
- 本改动仅新增 `.github/workflows/` 下的 2 个配置文件，未触碰任何业务源码。